### PR TITLE
chore: release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-31
+
 ### Fixed
 - Interface bumped to 120100 for WoW 12.1.0; the addon was flagged out of date and skipped at load
 - Spell teleports reported as permanently off cooldown on 12.x

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Shows the shortest path to your destination using teleports and portals
 ## Author: Sebastian Mendel
-## Version: 1.10.1
+## Version: 1.11.0
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.11.0 from the 12.1.0 maintenance work merged in #4. Two files: the TOC's `## Version` field, which is the addon's only version surface, and the `[Unreleased]` heading, which becomes `[1.11.0] - 2026-08-31`.

Minor rather than patch, because the release adds map data the addon did not have: The Coiled Isle, Vaults of Atal'Utek, Val, Naigtal and the two housing zones, eight dungeon and raid entrances from patches 11.1 through 12.1.0, and the Delve-O-Bot 7001.

## What the tag will trigger

`release.yml` fires on `v*` and, since #4, gates on both the test suite and luacheck before packaging — a tag no longer publishes an unlinted build. It then zips `dist/QuickRoute/`, refusing to zip a package missing any file its `.toc` references, publishes the GitHub release, and uploads to CurseForge and Wago. All three upload steps now fail the run rather than warning, so a release cannot finish green having published nothing.

This is the first release to run through those gates, so the run itself is worth watching.

## Verified on this branch

- 11626 assertions, 0 failures
- Luacheck 1.2.0: 0 warnings, 0 errors across 70 files
- `## Version: 1.11.0`, `## Interface: 120100`

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
