### PR TITLE
docs: link the addon sites the release publishes to

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Every release goes to all three at once, from the same build.
 
 | Source | |
 |---|---|
-| CurseForge | [QuickRoute](https://www.curseforge.com/projects/1461133) — or search "QuickRoute" in the CurseForge app or WoWUp |
+| CurseForge | [QuickRoute](https://www.curseforge.com/wow/addons/quickroute) — or search "QuickRoute" in the CurseForge app or WoWUp |
 | Wago | [QuickRoute](https://addons.wago.io/addons/quickroute) — or in the WagoApp |
 | GitHub | [Latest release](https://github.com/CybotTM/wow-quickroute/releases/latest) |
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <h1 align="center">QuickRoute</h1>
 
-![WoW 12.0](https://img.shields.io/badge/WoW-12.0%20Retail-148EFF)
+![WoW 12.1](https://img.shields.io/badge/WoW-12.1%20Retail-148EFF)
 ![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?logo=lua&logoColor=white)
-![Tests](https://img.shields.io/badge/tests-7754%20assertions-brightgreen)
+![Tests](https://img.shields.io/badge/tests-11626%20assertions-brightgreen)
 [![CI](https://github.com/CybotTM/wow-quickroute/actions/workflows/ci.yml/badge.svg)](https://github.com/CybotTM/wow-quickroute/actions/workflows/ci.yml)
 ![License](https://img.shields.io/github/license/CybotTM/wow-quickroute)
 
@@ -39,12 +39,20 @@ A World of Warcraft addon that calculates and displays the shortest path to any 
 
 ## Installation
 
-### Via CurseForge/WoWUp (Recommended)
-Install from CurseForge or WoWUp - dependencies are resolved automatically.
+Every release goes to all three at once, from the same build.
 
-### Manual Installation
-1. Download and extract to `World of Warcraft\_retail_\Interface\AddOns\QuickRoute`
-2. Restart WoW or `/reload`
+| Source | |
+|---|---|
+| CurseForge | [QuickRoute](https://www.curseforge.com/projects/1461133) — or search "QuickRoute" in the CurseForge app or WoWUp |
+| Wago | [QuickRoute](https://addons.wago.io/addons/quickroute) — or in the WagoApp |
+| GitHub | [Latest release](https://github.com/CybotTM/wow-quickroute/releases/latest) |
+
+An addon manager keeps QuickRoute current on its own, which matters here: the addon declares the game version it was built for, and WoW skips an addon whose declared version is behind the live patch unless "Load out of date AddOns" is ticked.
+
+### Manual installation
+1. Download `QuickRoute-<version>.zip` from the [latest release](https://github.com/CybotTM/wow-quickroute/releases/latest)
+2. Extract into `World of Warcraft\_retail_\Interface\AddOns\` so the folder is named `QuickRoute`
+3. Restart WoW or `/reload`
 
 ## Usage
 


### PR DESCRIPTION
The Installation section said "Install from CurseForge or WoWUp" and linked neither, so the two places a player actually gets the addon were findable only by searching for the name. Both IDs were already in the TOC — `X-Curse-Project-ID: 1461133`, `X-Wago-ID: Q6aRgaKW` — and both are what `release.yml` uploads to on every tag.

| Source | |
|---|---|
| CurseForge | project `1461133` |
| Wago | `quickroute` |
| GitHub | latest release |

## On the two store links

The Wago link is verified by content rather than by status code: the page at that slug names `CybotTM`, `Sebastian Mendel` and `Q6aRgaKW`, so it is this addon and not a name collision.

The CurseForge link could not be verified from here at all — Cloudflare answers `403` to every request from this machine, and it answers `403` to a slug invented as a control, so the status distinguishes nothing. It first went in as the project-ID form `…/projects/1461133`, taken from the TOC, because a guessed slug either works or silently points at a stranger's addon. The maintainer then supplied the real URL, which is now what the README carries.

## Also

Two badges claimed values that the 1.11.0 release made wrong — `WoW 12.0` and `7754 assertions`, now `12.1` and `11626`. Same class as the release-note lines corrected during #4: a number that was true once.

Docs only, no code touched.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
