### PR TITLE
fix: make the last-resort node connection deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Two test files left shared state behind, so the suite passed in one file order and failed in others: a mock frame method deleted rather than restored, and two saved-variables keys. CI now runs both orders.
+- The last-resort node connection in continent routing took whichever candidate Lua's hash order yielded, behind variables named as if it searched for the cheapest. It is deterministic now.
 
 ## [1.11.0] - 2026-08-31
 

--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -1106,29 +1106,45 @@ function PathCalculator:ConnectViaContinentRouting(nodeName, mapID, x, y)
             end
         end
 
-        -- Fallback: if no hub/city nodes found, connect to single best node.
+        -- Fallback: no hub or city was connected, so attach the node to one
+        -- other node rather than leaving it isolated.
+        --
+        -- Every candidate costs the same. This branch runs only when the node
+        -- has no continent the hub pass could price against, so there is
+        -- nothing to compare and no cheapest to find -- the previous shape
+        -- looked like a search (bestNode, bestTime, a < comparison) while the
+        -- compared value was the constant CROSS_CONTINENT_TIME, so it always
+        -- took whichever name pairs() happened to yield first. That is Lua hash
+        -- order: not stable between runs, and not reproducible from a bug
+        -- report. Sorting picks the same node every time; it is for
+        -- determinism, not for optimality.
+        --
         -- Candidates the overwrite rules refuse are skipped rather than
-        -- overwritten: this branch was the one write in the whole strategy
-        -- without that check, so it replaced measured walk edges and teleport
-        -- edges with a flat 300-second estimate. When every candidate is
-        -- refused there is nothing to do -- the node already has real edges to
-        -- them, which is the opposite of isolated.
+        -- overwritten: this was the one write in the whole strategy without
+        -- that check, so it replaced measured walk edges and teleport edges
+        -- with a flat estimate. When every candidate is refused there is
+        -- nothing to do -- the node already has real edges to them, which is
+        -- the opposite of isolated.
+        --
+        -- Not reached by any graph the addon builds: instrumented over 612
+        -- builds (every zone in ZoneAdjacencies, both factions, with and
+        -- without class portals) the branch was entered 0 times. It is kept as
+        -- defence in depth against a data change that leaves a node with no
+        -- continent, which is exactly the state it exists for.
         if connectCount == 0 then
-            local bestNode, bestTime = nil, math_huge
+            local eligible = {}
             for otherName, otherData in pairs(self.graph.nodes) do
                 if otherName ~= nodeName and otherData.mapID
                     and CanOverwriteWithTravel(self.graph, nodeName, otherName) then
-                    local baseTime = CROSS_CONTINENT_TIME
-                    if baseTime < bestTime then
-                        bestTime = baseTime
-                        bestNode = otherName
-                    end
+                    eligible[#eligible + 1] = otherName
                 end
             end
+            table_sort(eligible)
+            local bestNode = eligible[1]
             if bestNode then
                 local bestData = self.graph.nodes[bestNode]
                 local otherContinent = QR.GetContinentForZone and QR.GetContinentForZone(bestData.mapID)
-                self.graph:AddBidirectionalEdge(nodeName, bestNode, bestTime, "travel", {
+                self.graph:AddBidirectionalEdge(nodeName, bestNode, CROSS_CONTINENT_TIME, "travel", {
                     note = "Cross-continent travel (fallback)",
                     fromMapID = mapID,
                     toMapID = bestData.mapID,

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -1547,3 +1547,40 @@ T:run("Strategy 4 connects an unreachable node without a sub-second edge", funct
     t:assertEqual(0, #tooCheap,
         "no edge is under a second (" .. table.concat(tooCheap, ", ") .. ")")
 end)
+
+-------------------------------------------------------------------------------
+-- The last-resort fallback picks the same node every time
+-------------------------------------------------------------------------------
+
+-- Regression: the fallback read like a search -- bestNode, bestTime, a "<"
+-- comparison -- while the value compared was the constant CROSS_CONTINENT_TIME,
+-- so the condition was true exactly once and the node taken was whichever name
+-- pairs() yielded first. That is Lua hash order: it can differ between runs and
+-- between clients, and a bug report naming a route through it is not
+-- reproducible. Every candidate really does cost the same here, so the fix is
+-- determinism rather than a cheapest-first search.
+T:run("Strategy 4 fallback picks the lexicographically first candidate", function(t)
+    local graph = scratchGraph()
+    -- Map 99999 has no continent, so strategies 1-3 cannot connect it. The
+    -- candidates are plain zone nodes, not hubs or cities, so the hub pass
+    -- writes nothing and the fallback is what runs.
+    graph:AddNode("Orphan", { mapID = 99999, x = 0.5, y = 0.5, nodeType = "zone" })
+    local names = { "Zeta Outpost", "Alpha Landing", "Mid Station", "Beta Camp" }
+    for i, name in ipairs(names) do
+        graph:AddNode(name, { mapID = 84, x = 0.1 * i, y = 0.2, nodeType = "zone" })
+    end
+    QR.PathCalculator:BuildNodeIndex()
+
+    QR.PathCalculator:ConnectViaContinentRouting("Orphan", 99999, 0.5, 0.5)
+
+    local written = {}
+    for to, edge in pairs(graph.edges["Orphan"] or {}) do
+        written[#written + 1] = to
+        t:assertEqual("travel", edge.edgeType, "the fallback writes a travel edge")
+    end
+    t:assertEqual(1, #written,
+        "exactly one node is connected (got: " .. table.concat(written, ", ") .. ")")
+    t:assertEqual("Alpha Landing", written[1],
+        "and it is the lexicographically first candidate, not whichever the "
+            .. "hash order yielded (got: " .. tostring(written[1]) .. ")")
+end)


### PR DESCRIPTION
Closes #9.

The strategy-4 fallback read like a search — `bestNode`, `bestTime`, a `<` comparison — while the value compared was the constant `CROSS_CONTINENT_TIME`. So the condition was true exactly once, on the first eligible candidate, and the node connected was whichever name `pairs()` happened to yield. That is Lua hash order: not stable between runs or between clients, and not reproducible from a bug report.

## Which of the issue's two resolutions

The issue offered computing a real per-candidate time, or taking the first eligible with a comment. Neither, quite.

A real per-candidate time is not computable here. This branch runs only when the node has no continent for the hub pass to price against — that is *why* nothing else connected it — so there is nothing to compare and no cheapest to find. Every candidate genuinely costs the same.

But "first eligible" does not fix what the issue actually complains about. Its complaint is instability, and `pairs()` is exactly as unstable whether or not a comparison sits in front of it. So: collect the eligible names, sort, take the first. Determinism, not optimality, and the comment says which.

## Measured before changing anything

Instrumented over **612 graph builds** — every zone in `ZoneAdjacencies`, both factions, with and without class portals:

```
Graph builds:                    612
Strategy-4 fallback entered:       0
Strategy-4 fallback wrote:         0
```

It cannot be reached from any graph the addon builds today. That is worth knowing before touching it, and it is now recorded in the comment so the next person does not have to redo the measurement.

It is kept rather than deleted because the state it exists for — a node with no continent — is precisely what a data change reintroduces. That is not hypothetical: map `773` was in exactly that state until the 12.1.0 pass, four Tol Barad teleports pointing at an orphan UiMap with no continent and no adjacency.

## The guard is wired

Reverting the sort reddens the new test with `got: Zeta Outpost` against `expected: Alpha Landing` — so for that candidate set the hash order really does differ from sorted order, rather than agreeing with it by luck and leaving the assertion vacuous.

## Verified

- 11629 assertions, 0 failures
- Luacheck 1.2.0: 0 warnings, 0 errors across 70 files

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
