### PR TITLE
feat: dim teleport steps whose Use button combat is blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 - `/qrdungeons` opens the dungeon and raid picker. The module shipped in every release but nothing ever initialized it or opened it, so it was unreachable.
+- A teleport step rendered during combat is dimmed. It gets no Use button under lockdown, so it used to look identical to a step whose teleport is unavailable.
 
 ## [1.11.0] - 2026-08-31
 

--- a/QuickRoute/Modules/UI.lua
+++ b/QuickRoute/Modules/UI.lua
@@ -21,7 +21,7 @@ QR.UI = {
     frame = nil,
     stepLabels = {},
     stepLabelPool = {},  -- Pool of reusable step label frames
-    combatDisabledButtons = {},  -- Track buttons disabled during combat
+    combatDimmedSteps = {},  -- Step frames dimmed because combat blocks their teleport
     -- Cache tables for localized names (reduces repeated API calls)
     itemInfoCache = {},
     spellInfoCache = {},
@@ -36,6 +36,9 @@ QR.UI = {
 }
 
 local UI = QR.UI
+
+-- Alpha for a teleport step whose Use button combat is blocking
+local COMBAT_DIMMED_ALPHA = 0.5
 
 -- Localization shorthand
 local L = QR.L
@@ -678,7 +681,7 @@ function UI:UpdateRoute(result)
     end
 
     -- Clear combat disabled buttons tracking to prevent duplicates on refresh
-    wipe(self.combatDisabledButtons)
+    wipe(self.combatDimmedSteps)
 
     local waypoint = result.waypoint
     local steps = result.steps
@@ -897,14 +900,28 @@ function UI:SetupStepNavButton(stepFrame, step)
     return navButton
 end
 
+--- Dim a teleport step whose Use button combat is blocking, and remember it so
+-- OnCombatEnd can undim it.
+-- @param stepFrame Frame The step container frame
+function UI:MarkStepCombatDimmed(stepFrame)
+    if not stepFrame or not stepFrame.SetAlpha then
+        return
+    end
+    stepFrame:SetAlpha(COMBAT_DIMMED_ALPHA)
+    table_insert(self.combatDimmedSteps, stepFrame)
+end
+
 --- Configure a secure "Use" button for a teleport step
 -- @param stepFrame Frame The step container frame
 -- @param step table The step data
 -- @return Button|nil useButton The configured button, or nil if not applicable
 function UI:ConfigureStepUseButton(stepFrame, step)
-    -- Create "Use" secure button for teleport steps
-    -- Must check InCombatLockdown BEFORE GetButton to avoid wasting pool slots
-    if not (step.type == "teleport" and step.teleportID and QR.SecureButtons and not InCombatLockdown()) then
+    if not (step.type == "teleport" and step.teleportID and QR.SecureButtons) then
+        return nil
+    end
+
+    -- Must check InCombatLockdown BEFORE GetButton to avoid wasting pool slots.
+    if InCombatLockdown() then
         return nil
     end
 
@@ -1131,6 +1148,14 @@ function UI:CreateStepLabel(index, step, yOffset, status)
     -- Enable mouse for nav button clicks
     stepFrame:EnableMouse(true)
 
+    -- Last, because the progress styling above writes this frame's alpha too:
+    -- a teleport step rendered under lockdown gets no Use button, and without
+    -- this it looks identical to a step whose teleport is simply unavailable.
+    if step.type == "teleport" and step.teleportID
+        and not stepFrame.useButton and InCombatLockdown() then
+        self:MarkStepCombatDimmed(stepFrame)
+    end
+
     return stepFrame
 end
 
@@ -1160,6 +1185,9 @@ function UI:ReleaseStepLabelFrame(stepFrame)
     -- Clear stored data
     stepFrame.teleportID = nil
     stepFrame.sourceType = nil
+
+    -- A frame dimmed during combat must not come back out of the pool dim.
+    stepFrame:SetAlpha(1.0)
 
     -- Hide and unparent
     stepFrame:Hide()
@@ -1192,7 +1220,7 @@ function UI:ClearStepLabels()
         self:ReleaseStepLabelFrame(stepFrame)
     end
     wipe(self.stepLabels)
-    wipe(self.combatDisabledButtons)
+    wipe(self.combatDimmedSteps)
 end
 
 --- Clear the route display to default empty state
@@ -2018,15 +2046,16 @@ end
 -- restores a window that combat itself hid. TeleportPanel covers its own tab
 -- through SecureButtons:RegisterCombatEndCallback; this is the route tab.
 function UI:OnCombatEnd()
-    for _, btn in ipairs(self.combatDisabledButtons) do
-        if btn and btn.SetAlpha then
-            btn:SetAlpha(1.0)
-            if btn.text then
-                btn.text:SetTextColor(1, 0.82, 0)  -- Gold color
-            end
-        end
-    end
-    wipe(self.combatDisabledButtons)
+    -- Undimming is a re-render rather than SetAlpha(1.0): the progress styling
+    -- writes this same alpha -- 0.6 for a completed step -- so forcing 1.0
+    -- would erase that. The refresh below reapplies both, and frames are reset
+    -- to full alpha when they return to the pool.
+    --
+    -- No separate "was anything dimmed" branch: a dimmed step is by definition
+    -- a teleport step without a Use button, which is exactly what the loop
+    -- below looks for. Removing such a branch changed no test, which is how it
+    -- was found to be redundant rather than protective.
+    wipe(self.combatDimmedSteps)
 
     if not (QR.MainFrame and QR.MainFrame.isShowing
         and QR.MainFrame.activeTab == "route" and self.frame) then

--- a/tests/test_ui.lua
+++ b/tests/test_ui.lua
@@ -1596,3 +1596,75 @@ T:run("GetLocalizedItemInfo: an item that is not cached yet returns nil, uncache
     t:assertNotNil(name2, "the second call gets the name once the client has it")
     t:assertNotNil(QR.UI.itemInfoCache[itemID], "and that one is cached")
 end)
+
+-------------------------------------------------------------------------------
+-- Teleport steps rendered during combat are dimmed, not silently button-less
+-------------------------------------------------------------------------------
+
+-- Regression: UI.combatDisabledButtons was wiped in three places and iterated in
+-- one, and nothing ever inserted into it. The dimming it was named for did not
+-- exist, so a teleport step rendered under lockdown looked exactly like a step
+-- whose teleport is unavailable -- same text, no Use button, no signal which of
+-- the two it was.
+T:run("UI: a teleport step rendered in combat is dimmed", function(t)
+    resetState()
+    ensureUIFrame()
+    QR.SecureButtons:Initialize()
+    MockWoW.config.ownedToys[140192] = true
+    QR.PlayerInventory:ScanAll()
+    MockWoW.config.currentMapID = 84
+    setMapPinWaypoint(627, 0.5, 0.5)
+    QR.MainFrame.isShowing = true
+    QR.MainFrame.activeTab = "route"
+
+    MockWoW.config.inCombatLockdown = true
+    QR.UI:RefreshRoute()
+
+    local teleportSteps, dimmed = 0, 0
+    for _, stepFrame in ipairs(QR.UI.stepLabels or {}) do
+        if stepFrame.teleportID then
+            teleportSteps = teleportSteps + 1
+            if stepFrame:GetAlpha() < 1.0 then dimmed = dimmed + 1 end
+        end
+    end
+    t:assertGreaterThan(teleportSteps, 0, "the route has a teleport step")
+    t:assertEqual(teleportSteps, dimmed,
+        "every teleport step is dimmed while combat blocks its button ("
+            .. tostring(dimmed) .. " of " .. tostring(teleportSteps) .. ")")
+    t:assertGreaterThan(#QR.UI.combatDimmedSteps, 0,
+        "and each one is recorded so it can be undimmed")
+
+    MockWoW.config.inCombatLockdown = false
+    local handler = QR.combatFrame and QR.combatFrame:GetScript("OnEvent")
+    t:assertNotNil(handler, "the combat manager is reachable")
+    if not handler then return end
+    handler(QR.combatFrame, "PLAYER_REGEN_ENABLED")
+
+    local stillDim = 0
+    for _, stepFrame in ipairs(QR.UI.stepLabels or {}) do
+        if stepFrame:GetAlpha() < 1.0 then stillDim = stillDim + 1 end
+    end
+    t:assertEqual(0, stillDim,
+        "and nothing stays dim once combat ends (still dim: " .. tostring(stillDim) .. ")")
+
+    QR.MainFrame.isShowing = false
+end)
+
+-- A dimmed frame goes back into the pool like any other. Without resetting its
+-- alpha it comes back dim on a route rendered out of combat, which is the same
+-- wrong signal in the opposite direction.
+T:run("UI: a step frame does not come back from the pool dimmed", function(t)
+    resetState()
+    ensureUIFrame()
+
+    local frame = QR.UI:GetStepLabelFrame()
+    QR.UI:MarkStepCombatDimmed(frame)
+    t:assert(frame:GetAlpha() < 1.0, "the frame is dimmed")
+
+    QR.UI:ReleaseStepLabelFrame(frame)
+    local reused = QR.UI:GetStepLabelFrame()
+    t:assertEqual(frame, reused, "the pool handed back the same frame")
+    t:assertEqual(1.0, reused:GetAlpha(),
+        "at full alpha (got: " .. tostring(reused:GetAlpha()) .. ")")
+    QR.UI:ReleaseStepLabelFrame(reused)
+end)


### PR DESCRIPTION
Closes #7. You chose "implement the dimming" over deleting the field.

`UI.combatDisabledButtons` was wiped in three places and iterated in one, and nothing ever inserted into it. The dimming it was named for did not exist, so a teleport step rendered under lockdown looked exactly like a step whose teleport is unavailable — same text, no Use button, no signal which of the two it was.

The field is renamed to `combatDimmedSteps`, because what gets dimmed is the *step*, not a button. During combat there is no button to dim: `GetButton` refuses under lockdown and a secure frame cannot be configured there. That is precisely why the step needs a signal of its own, and it is the point I flagged when you picked this option.

## Three things that only showed up while building it

**The dim has to run last.** `CreateStepLabel` already writes the frame's alpha as the route-progress channel — `0.6` for a completed step — and that runs *after* `ConfigureStepUseButton`. Dimming from inside the button path was silently overwritten: the frame was recorded as dimmed while its alpha read `1`. Measured, not reasoned:

```
Schritt 1: frame.teleportID=140192 alpha=1
gedimmt registriert: 1
```

**Undimming is a re-render, not `SetAlpha(1.0)`.** Forcing full alpha would erase the `0.6` a completed step carries. `OnCombatEnd` already re-renders when a teleport step lacks its button — which is exactly the dimmed case.

**`ReleaseStepLabelFrame` now resets alpha.** Frames are pooled, and a dimmed one came back dim on a route rendered *out* of combat: the same wrong signal in the other direction.

## And one thing removed rather than added

A "was anything dimmed" branch in `OnCombatEnd`. Deleting it changed no test, because the existing condition already covers the case — a dimmed step is by definition a teleport step without a Use button. Rather than keep a branch no mutation can redden, it is gone, with a comment saying why so it is not reintroduced as if it were protective.

## Verified

| mutation | test that fails |
|---|---|
| remove the dim | `a teleport step rendered in combat is dimmed` |
| remove the pool alpha reset | `a step frame does not come back from the pool dimmed` |

11634 assertions, 0 failures. Luacheck 1.2.0: 0 warnings, 0 errors.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
