### PR TITLE
feat: route through the dungeon teleports the player knows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `/qrdungeons` opens the dungeon and raid picker. The module shipped in every release but nothing ever initialized it or opened it, so it was unreachable.
 - A teleport step rendered during combat is dimmed. It gets no Use button under lockdown, so it used to look identical to a step whose teleport is unavailable.
 - `/qrverifymap [mapID]` reports what the client says about a map and what the addon believes about it, side by side, in the copyable window. For the questions that cannot be answered from the data — which map a teleport actually lands on, whether a service is still there.
+- Dungeon and raid teleports the player knows are now routes. A character with the Mythic+ teleport for a dungeon was sent there on foot: the addon knew the entrance and knew the spell, and nothing connected the two.
 
 ## [1.11.0] - 2026-08-31
 

--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -211,6 +211,17 @@ function PathCalculator:BuildGraph()
         buildError = buildError or err
     end
 
+    -- Dungeon teleports the player knows. Must come after AddDungeonNodes:
+    -- the nodes these edges point at do not exist before it.
+    success, err = pcall(function()
+        self:AddDungeonTeleportEdges()
+    end)
+    if not success then
+        QR:Error("AddDungeonTeleportEdges failed: " .. tostring(err))
+        buildSuccess = false
+        buildError = buildError or err
+    end
+
     -- IMPORTANT: Connect all nodes on the same map with walking edges
     -- This ensures teleport destinations connect to portal hubs on the same map
     success, err = pcall(function()
@@ -1158,6 +1169,53 @@ function PathCalculator:ConnectViaContinentRouting(nodeName, mapID, x, y)
         if connectCount > 0 then
             QR:Debug(string_format("  -> Cross-continent: connected to %d hub/city nodes", connectCount))
         end
+    end
+end
+
+--- Add an edge from the player to each dungeon they can teleport to.
+-- Separate from AddPlayerTeleportEdges because that one runs before the dungeon
+-- nodes exist and builds its own destination node from data.mapID, which these
+-- spells do not carry: a dungeon teleport lands at an entrance the graph already
+-- models, so it should reuse that node rather than invent a second one beside it.
+function PathCalculator:AddDungeonTeleportEdges()
+    if not QR.DungeonTeleportSpells or not QR.PlayerInventory then
+        return
+    end
+
+    -- Index the dungeon nodes by instance, so a spell finds its entrance in one
+    -- lookup rather than a scan per spell.
+    local nodeByInstance = {}
+    for nodeName, nodeData in pairs(self.graph.nodes) do
+        if nodeData.isDungeon and nodeData.journalInstanceID then
+            nodeByInstance[nodeData.journalInstanceID] = nodeName
+        end
+    end
+    if not next(nodeByInstance) then
+        return
+    end
+
+    local teleports = QR.PlayerInventory:GetAllTeleports()
+    local added = 0
+    for teleportID, teleport in pairs(teleports) do
+        local data = teleport.data
+        local instanceID = data and data.journalInstanceID
+        local destName = instanceID and nodeByInstance[instanceID]
+        if destName then
+            local includeCooldown = QR.db and QR.db.considerCooldowns
+            local travelTime = QR.TravelTime:GetEffectiveTime(teleportID, data, includeCooldown)
+            travelTime = travelTime + (QR.db and QR.db.loadingScreenTime or 0)
+
+            self.graph:AddEdge(PLAYER_NODE, destName, travelTime, "teleport", {
+                teleportID = teleportID,
+                teleportData = data,
+                sourceType = teleport.sourceType,
+            })
+            added = added + 1
+        end
+    end
+
+    if added > 0 then
+        QR:Debug(string_format("PathCalculator: %d dungeon teleport edge(s)", added))
     end
 end
 

--- a/QuickRoute/Data/DungeonTeleports.lua
+++ b/QuickRoute/Data/DungeonTeleports.lua
@@ -1,0 +1,207 @@
+-- DungeonTeleports.lua
+-- Spells that teleport the player to a dungeon or raid entrance.
+--
+-- Derived from the client's own tables, not hand-listed: every SpellName row
+-- named "Teleport: <X>" where X is a JournalInstance name. That is a generous
+-- match on purpose -- it catches the Mythic+ rewards this file was added for
+-- and the older attunement teleports alike, and it cannot be narrowed from
+-- outside the game because no client table marks which are which.
+--
+-- The generosity is safe because nothing here is used until IsSpellKnown says
+-- the player has it: a spell nobody can learn is inert, and a boss ability of
+-- the same name is never known. What a wrong entry would cost is a teleport
+-- offered to a dungeon it does not lead to, which /qrscan lists and
+-- /qrverifymap can be pointed at.
+--
+-- Regenerate: match SpellName.Name_lang against JournalInstance.Name_lang.
+-- Several instances have more than one spell; both are kept, since they share
+-- the journalInstanceID and the unlearned one never becomes an edge.
+local ADDON_NAME, QR = ...
+
+QR.DungeonTeleportSpells = {
+    -- Algeth'ar Academy
+    [396126] = { journalInstanceID = 1201, destination = "Algeth'ar Academy" },
+    -- Altar of Fangs
+    [1289772] = { journalInstanceID = 1322, destination = "Altar of Fangs" },
+    -- Antorus, the Burning Throne
+    [253524] = { journalInstanceID = 946, destination = "Antorus, the Burning Throne" },
+    -- Ara-Kara, City of Echoes
+    [442929] = { journalInstanceID = 1271, destination = "Ara-Kara, City of Echoes" },
+    -- Atal'Dazar
+    [272256] = { journalInstanceID = 968, destination = "Atal'Dazar" },
+    -- Auchindoun
+    [169764] = { journalInstanceID = 547, destination = "Auchindoun" },
+    -- Baradin Hold
+    [219338] = { journalInstanceID = 75, destination = "Baradin Hold" },
+    -- Black Rook Hold
+    [205373] = { journalInstanceID = 740, destination = "Black Rook Hold" },
+    [426400] = { journalInstanceID = 740, destination = "Black Rook Hold" },
+    -- Black Temple
+    [41234] = { journalInstanceID = 751, destination = "Black Temple" },
+    [1248491] = { journalInstanceID = 751, destination = "Black Temple" },
+    -- Blackrock Foundry
+    [169771] = { journalInstanceID = 457, destination = "Blackrock Foundry" },
+    -- Bloodmaul Slag Mines
+    [151895] = { journalInstanceID = 385, destination = "Bloodmaul Slag Mines" },
+    [169762] = { journalInstanceID = 385, destination = "Bloodmaul Slag Mines" },
+    -- Brackenhide Hollow
+    [396129] = { journalInstanceID = 1196, destination = "Brackenhide Hollow" },
+    -- Cathedral of Eternal Night
+    [240988] = { journalInstanceID = 900, destination = "Cathedral of Eternal Night" },
+    -- Cinderbrew Meadery
+    [442932] = { journalInstanceID = 1272, destination = "Cinderbrew Meadery" },
+    -- City of Threads
+    [442927] = { journalInstanceID = 1274, destination = "City of Threads" },
+    -- Court of Stars
+    [220052] = { journalInstanceID = 800, destination = "Court of Stars" },
+    -- Crucible of Storms
+    [286637] = { journalInstanceID = 1177, destination = "Crucible of Storms" },
+    -- Darkflame Cleft
+    [442930] = { journalInstanceID = 1210, destination = "Darkflame Cleft" },
+    -- Darkheart Thicket
+    [205374] = { journalInstanceID = 762, destination = "Darkheart Thicket" },
+    -- Dawn of the Infinite
+    [426121] = { journalInstanceID = 1209, destination = "Dawn of the Infinite" },
+    -- De Other Side
+    [348537] = { journalInstanceID = 1188, destination = "De Other Side" },
+    -- Den of Nalorakk
+    [1289773] = { journalInstanceID = 1311, destination = "Den of Nalorakk" },
+    -- Eye of Azshara
+    [205376] = { journalInstanceID = 716, destination = "Eye of Azshara" },
+    -- Freehold
+    [272262] = { journalInstanceID = 1001, destination = "Freehold" },
+    -- Grim Batol
+    [396121] = { journalInstanceID = 71, destination = "Grim Batol" },
+    -- Grimrail Depot
+    [169766] = { journalInstanceID = 536, destination = "Grimrail Depot" },
+    -- Halls of Atonement
+    [325777] = { journalInstanceID = 1185, destination = "Halls of Atonement" },
+    [348534] = { journalInstanceID = 1185, destination = "Halls of Atonement" },
+    -- Halls of Infusion
+    [396130] = { journalInstanceID = 1204, destination = "Halls of Infusion" },
+    -- Halls of Valor
+    [205377] = { journalInstanceID = 721, destination = "Halls of Valor" },
+    [213529] = { journalInstanceID = 721, destination = "Halls of Valor" },
+    [228931] = { journalInstanceID = 721, destination = "Halls of Valor" },
+    [232624] = { journalInstanceID = 721, destination = "Halls of Valor" },
+    -- Hellfire Citadel
+    [187328] = { journalInstanceID = 669, destination = "Hellfire Citadel" },
+    -- Highmaul
+    [169770] = { journalInstanceID = 477, destination = "Highmaul" },
+    -- Iron Docks
+    [169763] = { journalInstanceID = 558, destination = "Iron Docks" },
+    -- Karazhan
+    [230118] = { journalInstanceID = 745, destination = "Karazhan" },
+    [373515] = { journalInstanceID = 745, destination = "Karazhan" },
+    -- Kings' Rest
+    [272261] = { journalInstanceID = 1041, destination = "Kings' Rest" },
+    [1289778] = { journalInstanceID = 1041, destination = "Kings' Rest" },
+    -- Magisters' Terrace
+    [1255433] = { journalInstanceID = 1300, destination = "Magisters' Terrace" },
+    -- Maisara Caverns
+    [1255247] = { journalInstanceID = 1315, destination = "Maisara Caverns" },
+    -- Maw of Souls
+    [205392] = { journalInstanceID = 727, destination = "Maw of Souls" },
+    -- Mists of Tirna Scithe
+    [348533] = { journalInstanceID = 1184, destination = "Mists of Tirna Scithe" },
+    -- Murder Row
+    [1248186] = { journalInstanceID = 1304, destination = "Murder Row" },
+    [1253942] = { journalInstanceID = 1304, destination = "Murder Row" },
+    [1289775] = { journalInstanceID = 1304, destination = "Murder Row" },
+    -- Neltharion's Lair
+    [205379] = { journalInstanceID = 767, destination = "Neltharion's Lair" },
+    -- Neltharus
+    [396128] = { journalInstanceID = 1199, destination = "Neltharus" },
+    -- Nexus-Point Xenas
+    [1255391] = { journalInstanceID = 1316, destination = "Nexus-Point Xenas" },
+    -- Operation: Floodgate
+    [1218105] = { journalInstanceID = 1298, destination = "Operation: Floodgate" },
+    -- Operation: Mechagon
+    [300433] = { journalInstanceID = 1178, destination = "Operation: Mechagon" },
+    -- Pit of Saron
+    [1255366] = { journalInstanceID = 278, destination = "Pit of Saron" },
+    -- Plaguefall
+    [348531] = { journalInstanceID = 1183, destination = "Plaguefall" },
+    -- Priory of the Sacred Flame
+    [442923] = { journalInstanceID = 1267, destination = "Priory of the Sacred Flame" },
+    -- Return to Karazhan
+    [245588] = { journalInstanceID = 860, destination = "Return to Karazhan" },
+    -- Ruby Life Pools
+    [1289780] = { journalInstanceID = 1202, destination = "Ruby Life Pools" },
+    -- Sanguine Depths
+    [348538] = { journalInstanceID = 1189, destination = "Sanguine Depths" },
+    -- Seat of the Triumvirate
+    [252631] = { journalInstanceID = 945, destination = "Seat of the Triumvirate" },
+    -- Shadowmoon Burial Grounds
+    [169768] = { journalInstanceID = 537, destination = "Shadowmoon Burial Grounds" },
+    [396131] = { journalInstanceID = 537, destination = "Shadowmoon Burial Grounds" },
+    -- Shrine of the Storm
+    [272263] = { journalInstanceID = 1036, destination = "Shrine of the Storm" },
+    -- Siege of Boralus
+    [272264] = { journalInstanceID = 1023, destination = "Siege of Boralus" },
+    [272265] = { journalInstanceID = 1023, destination = "Siege of Boralus" },
+    -- Skyreach
+    [169765] = { journalInstanceID = 476, destination = "Skyreach" },
+    -- Spires of Ascension
+    [348535] = { journalInstanceID = 1186, destination = "Spires of Ascension" },
+    -- Temple of Sethraliss
+    [272267] = { journalInstanceID = 1030, destination = "Temple of Sethraliss" },
+    [1289782] = { journalInstanceID = 1030, destination = "Temple of Sethraliss" },
+    -- Temple of the Jade Serpent
+    [396132] = { journalInstanceID = 313, destination = "Temple of the Jade Serpent" },
+    -- The Azure Vault
+    [396125] = { journalInstanceID = 1203, destination = "The Azure Vault" },
+    -- The Blinding Vale
+    [1289776] = { journalInstanceID = 1309, destination = "The Blinding Vale" },
+    -- The Dawnbreaker
+    [442931] = { journalInstanceID = 1270, destination = "The Dawnbreaker" },
+    -- The Eternal Palace
+    [302415] = { journalInstanceID = 1179, destination = "The Eternal Palace" },
+    -- The Everbloom
+    [426410] = { journalInstanceID = 556, destination = "The Everbloom" },
+    -- The Necrotic Wake
+    [348529] = { journalInstanceID = 1182, destination = "The Necrotic Wake" },
+    -- The Nighthold
+    [232457] = { journalInstanceID = 786, destination = "The Nighthold" },
+    [232539] = { journalInstanceID = 786, destination = "The Nighthold" },
+    [262338] = { journalInstanceID = 786, destination = "The Nighthold" },
+    [265577] = { journalInstanceID = 786, destination = "The Nighthold" },
+    -- The Nokhud Offensive
+    [396123] = { journalInstanceID = 1198, destination = "The Nokhud Offensive" },
+    -- The Rookery
+    [442925] = { journalInstanceID = 1268, destination = "The Rookery" },
+    -- The Stonevault
+    [442926] = { journalInstanceID = 1269, destination = "The Stonevault" },
+    -- The Underrot
+    [272269] = { journalInstanceID = 1022, destination = "The Underrot" },
+    -- The Vortex Pinnacle
+    [408371] = { journalInstanceID = 68, destination = "The Vortex Pinnacle" },
+    -- Theater of Pain
+    [348536] = { journalInstanceID = 1187, destination = "Theater of Pain" },
+    -- Throne of the Tides
+    [426132] = { journalInstanceID = 65, destination = "Throne of the Tides" },
+    [426464] = { journalInstanceID = 65, destination = "Throne of the Tides" },
+    -- Tol Dagor
+    [272270] = { journalInstanceID = 1002, destination = "Tol Dagor" },
+    -- Tomb of Sargeras
+    [240991] = { journalInstanceID = 875, destination = "Tomb of Sargeras" },
+    -- Trial of Valor
+    [232892] = { journalInstanceID = 861, destination = "Trial of Valor" },
+    -- Uldaman: Legacy of Tyr
+    [396127] = { journalInstanceID = 1197, destination = "Uldaman: Legacy of Tyr" },
+    -- Uldir
+    [272280] = { journalInstanceID = 1031, destination = "Uldir" },
+    -- Upper Blackrock Spire
+    [169769] = { journalInstanceID = 559, destination = "Upper Blackrock Spire" },
+    -- Vault of the Wardens
+    [205395] = { journalInstanceID = 707, destination = "Vault of the Wardens" },
+    -- Voidscar Arena
+    [1286119] = { journalInstanceID = 1313, destination = "Voidscar Arena" },
+    [1289777] = { journalInstanceID = 1313, destination = "Voidscar Arena" },
+    -- Waycrest Manor
+    [272271] = { journalInstanceID = 1021, destination = "Waycrest Manor" },
+    -- Windrunner Spire
+    [1254840] = { journalInstanceID = 1299, destination = "Windrunner Spire" },
+    -- Zul'Farrak
+    [51958] = { journalInstanceID = 241, destination = "Zul'Farrak" },
+}

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -245,6 +245,24 @@ function PlayerInventory:ScanSpells()
         end
     end
 
+    -- Dungeon and raid teleports. The table is a generous name match against the
+    -- client's instance list, so IsSpellKnown is what makes it correct: a spell
+    -- nobody can learn never lands here, and neither does a boss ability that
+    -- happens to share the name.
+    if QR.DungeonTeleportSpells then
+        for spellID, data in pairs(QR.DungeonTeleportSpells) do
+            if not self.spells[spellID] and IsSpellKnown(spellID) then
+                -- No marker field: GetAllTeleports would drop it, and the
+                -- graph step keys on data.journalInstanceID, which is what
+                -- actually distinguishes these.
+                self.spells[spellID] = {
+                    id = spellID,
+                    data = data,
+                }
+            end
+        end
+    end
+
     return self.spells
 end
 

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -28,6 +28,7 @@ Data\TeleportItems.lua
 Data\Portals.lua
 Data\ZoneAdjacency.lua
 Data\DungeonEntrances.lua
+Data\DungeonTeleports.lua
 Data\ServicePOIs.lua
 
 # Core

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A World of Warcraft addon that calculates and displays the shortest path to any 
 - **Portal Knowledge:** Knows all portal hub locations and connections
 - **Faction-Aware:** Respects Alliance/Horde restrictions for portals and items
 - **Class-Aware:** Includes class-specific teleports (Mage, Druid, Monk, DK, Shaman, DH)
+- **Dungeon Teleports:** Mythic+ and attunement teleports route to the dungeon entrance
 - **TomTom Integration:** Automatically detects TomTom waypoints
 - **Auto-Destination:** Automatically routes to super-tracked quests/waypoints
 - **World Map Teleport Button:** One-click teleport button on the world map

--- a/tests/addon_loader.lua
+++ b/tests/addon_loader.lua
@@ -41,6 +41,7 @@ function AddonLoader:Load(MockWoW, options)
         "Data/Portals.lua",
         "Data/ZoneAdjacency.lua",
         "Data/DungeonEntrances.lua",
+        "Data/DungeonTeleports.lua",
         "Data/ServicePOIs.lua",
         "Core/Graph.lua",
         "Core/TravelTime.lua",

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -1584,3 +1584,67 @@ T:run("Strategy 4 fallback picks the lexicographically first candidate", functio
         "and it is the lexicographically first candidate, not whichever the "
             .. "hash order yielded (got: " .. tostring(written[1]) .. ")")
 end)
+
+-------------------------------------------------------------------------------
+-- Dungeon teleports become edges to the entrance the graph already has
+-------------------------------------------------------------------------------
+
+-- A player who owns a dungeon teleport was routed to that dungeon's entrance on
+-- foot: the addon knew the entrance and knew the spell existed as a spell, but
+-- nothing connected the two. AddPlayerTeleportEdges cannot do it -- it runs
+-- before the dungeon nodes exist and builds its destination from data.mapID,
+-- which these spells do not carry.
+local function firstKnownDungeonTeleport(QR)
+    local ids = {}
+    for spellID in pairs(QR.DungeonTeleportSpells or {}) do ids[#ids + 1] = spellID end
+    table.sort(ids)
+    for _, spellID in ipairs(ids) do
+        local data = QR.DungeonTeleportSpells[spellID]
+        local inst = QR.DungeonData and QR.DungeonData.instances
+            and QR.DungeonData.instances[data.journalInstanceID]
+        if inst and inst.zoneMapID and inst.x and inst.y and inst.name then
+            return spellID, data, "Dungeon: " .. inst.name
+        end
+    end
+end
+
+T:run("A known dungeon teleport becomes an edge to that dungeon's node", function(t)
+    resetState()
+    local spellID, data, nodeName = firstKnownDungeonTeleport(QR)
+    t:assertNotNil(spellID, "the data has a teleport whose instance the graph models")
+    if not spellID then return end
+
+    MockWoW.config.knownSpells = { [spellID] = true }
+    QR.PlayerInventory:ScanAll()
+    QR.PathCalculator.graphDirty = true
+    QR:InitializeGraph()
+
+    local graph = QR.PathCalculator.graph
+    t:assertNotNil(graph and graph.nodes[nodeName],
+        "the dungeon node exists (" .. tostring(nodeName) .. ")")
+    local edge = graph and graph:GetEdge("Player Location", nodeName)
+    t:assertNotNil(edge, "and the player has an edge to it")
+    if not edge then return end
+    t:assertEqual("teleport", edge.edgeType, "which is a teleport edge")
+    t:assertEqual(spellID, edge.data and edge.data.teleportID,
+        "carrying the spell ID the Use button needs")
+end)
+
+T:run("An unknown dungeon teleport creates no edge", function(t)
+    -- The data table is a generous name match against the client's instance
+    -- list, so IsSpellKnown is what makes it correct. A spell the player does
+    -- not have must not shorten any route.
+    resetState()
+    local spellID, _, nodeName = firstKnownDungeonTeleport(QR)
+    if not spellID then return end
+
+    MockWoW.config.knownSpells = {}
+    QR.PlayerInventory:ScanAll()
+    QR.PathCalculator.graphDirty = true
+    QR:InitializeGraph()
+
+    local graph = QR.PathCalculator.graph
+    local edge = graph and graph:GetEdge("Player Location", nodeName)
+    t:assert(edge == nil or edge.edgeType ~= "teleport",
+        "no teleport edge for a spell the player does not know")
+end)


### PR DESCRIPTION
Closes #1.

A character holding the Mythic+ teleport for a dungeon was routed there on foot. The addon already knew the entrance — `AddDungeonNodes` builds a node per instance — and already scanned spells. Nothing connected the two.

## The data

Derived from the client's own tables rather than hand-listed: every `SpellName` row named `Teleport: <X>` where `X` is a `JournalInstance` name. **102 spells across 83 instances.**

That match is deliberately generous. It catches the Mythic+ rewards this issue is about *and* the older attunement teleports, and it cannot be narrowed from outside the game: no client table marks which is which, and `SpellCooldowns` records nothing for any of them. Fourteen instances have more than one candidate — `Halls of Valor` has four — and both are kept, since they share the `journalInstanceID` and only one can be learned.

**The generosity is safe because `IsSpellKnown` gates it.** A spell nobody can learn never becomes an edge, and neither does a boss ability of the same name.

That is not an argument, it is measured. Removing the gate reddens an *unrelated existing* route test:

```
CalculatePath: a destination inside a capital keeps its real legs:
  crossing between two capitals is not priced under a minute (got 25s)
```

A teleport the player does not own would shorten routes it has nothing to do with, and the suite already catches that.

## Why a separate build step

`AddDungeonTeleportEdges` is not part of `AddPlayerTeleportEdges`, for two reasons that are easy to get wrong:

- That one runs **before** `AddDungeonNodes`, so the nodes these edges point at do not exist yet. Moving the new step above `AddDungeonNodes` reddens the test.
- It builds its destination node from `data.mapID`, which these spells do not carry. A dungeon teleport lands at an entrance the graph already models, so it reuses that node rather than inventing a second one beside it.

No marker field on the scanned spell either: `GetAllTeleports` copies only `isClass` and `isMageTeleport`, so an `isDungeonTeleport` flag would be dropped before anything read it. The step keys on `data.journalInstanceID`, which is what actually distinguishes these.

## What is not settled

Whether every dungeon teleport follows the `Teleport: <instance>` convention. If one does not, it is invisible to this derivation and to any test built on it, and there is no way to enumerate the true set from outside the game. A wrong entry costs a teleport offered to a dungeon it does not lead to; `/qrscan` lists what was detected and `/qrverifymap` (#16) can be pointed at the destination.

## Verified

| mutation | test that fails |
|---|---|
| remove the build step | `and the player has an edge to it` |
| remove the `IsSpellKnown` gate | the capital-crossing route test, plus the spell-ID assertion |
| move the step above `AddDungeonNodes` | `and the player has an edge to it` |

11632 assertions, 0 failures. Luacheck 1.2.0: 0 warnings, 0 errors across 71 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
