### PR TITLE
chore: release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-31
+
 ### Fixed
 - Two test files left shared state behind, so the suite passed in one file order and failed in others: a mock frame method deleted rather than restored, and two saved-variables keys. CI now runs both orders.
 - The last-resort node connection in continent routing took whichever candidate Lua's hash order yielded, behind variables named as if it searched for the cheapest. It is deterministic now.

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Shows the shortest path to your destination using teleports and portals
 ## Author: Sebastian Mendel
-## Version: 1.11.0
+## Version: 1.12.0
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.12.0 from the eight pull requests merged since 1.11.0. Two files: the TOC's `## Version` field, the addon's only version surface, and the `[Unreleased]` heading, which becomes `[1.12.0] - 2026-08-31`.

Minor rather than patch, because four of the eight are additions.

## What it carries

**Fixed**

- The test suite passed in one file order and failed in others. One file deleted a mock frame method instead of restoring it and left two saved-variables keys behind. Measured over 30 random file orders: 19 red before, 0 after. CI now runs both orders. (#8)
- The last-resort node connection in continent routing took whichever candidate Lua's hash order yielded, behind variables named as if it searched for the cheapest. (#9)
- A character with no teleports had no route at all from anywhere the graph has no other node for — Thunder Bluff, Darnassus, Ashran and 26 other zones. 29 zones with no route before, 21 after. (part of #2)

**Added**

- `/qrdungeons` opens the dungeon and raid picker, which shipped in every release with nothing to initialize or open it. (#6)
- Dungeon and raid teleports the player knows are now routes — 102 spells across 83 instances, derived from the client's own tables. (#1)
- A teleport step rendered during combat is dimmed, so it no longer looks identical to a step whose teleport is unavailable. (#7)
- `/qrverifymap [mapID]` reports what the client says about a map and what the addon believes about it, side by side. (unblocks #5 and #3)

## Still open, deliberately

- **#2** — the flight network itself. Every edge weight would be a guess: no API returns a flight duration, and the per-character node count and `GetTaxiNodesForMap` behaviour are unverified offline.
- **#5** — cast Zen Pilgrimage, run `/qrverifymap`, and the map it lands on is the first line.
- **#3** — stand in Undercity and Darnassus, run `/qrverifymap` in each.

## Verified on this branch

- 11666 assertions, 0 failures, in both file orders
- Luacheck 1.2.0: 0 warnings, 0 errors across 71 files
- `## Version: 1.12.0`, `## Interface: 120100`

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
