### PR TITLE
chore: release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-31
+
 ### Added
 - Flight paths are part of the travel graph. 141 zones with a flight master, positioned from the client's own tables and connected where the player has discovered them. A flight step's waypoint is the flight master itself. Measured for a character with no teleports routing to Stormwind: 18 zones get a faster route and none get a slower one; Silithus drops from 855 to 542 seconds and Mount Hyjal from 705 to 418.
 

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Shows the shortest path to your destination using teleports and portals
 ## Author: Sebastian Mendel
-## Version: 1.12.0
+## Version: 1.13.0
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.13.0 from the flight-network work merged as [#20](https://github.com/CybotTM/wow-quickroute/pull/20). Two files: the TOC's `## Version` field, the addon's only version surface, and the `[Unreleased]` heading, which becomes `[1.13.0] - 2026-08-31`.

Minor rather than patch, because the flight network is an addition.

## What it carries

**Added** — flight paths are part of the travel graph, closing [#2](https://github.com/CybotTM/wow-quickroute/issues/2). 141 zones with a flight master, derived from the client's own tables rather than surveyed, connected only where the player has actually discovered them, and each flight step's waypoint is the flight master itself.

Measured for a character with no teleports routing to Stormwind, across the 94 flight zones that have a graph node: 18 get a faster route, 63 are unchanged, none get a slower one. Silithus 855s → 542s, Mount Hyjal 705s → 418s, Orgrimmar 645s → 514s, Badlands 307s → 185s.

## Still open, deliberately

- [#21](https://github.com/CybotTM/wow-quickroute/issues/21) — Pandaria and Draenor still have no modelled way out. Flights do not cross world maps, which is correct game behaviour, so this was never what the flight network would fix. It needs return-portal destinations that only a live client can supply.
- [#22](https://github.com/CybotTM/wow-quickroute/issues/22) — faction-specific flight points are offered to both factions. Pre-existing, and the fix needs a decision about whether to keep two points per zone.
- [#23](https://github.com/CybotTM/wow-quickroute/issues/23) — a route step's waypoint map and coordinates can come from different nodes. Two of its three cases predate this branch.
- [#5](https://github.com/CybotTM/wow-quickroute/issues/5) and [#3](https://github.com/CybotTM/wow-quickroute/issues/3) — both need one person standing in one place with `/qrverifymap`.

## Verified on this branch

- 13066 Lua assertions, 0 failures, in both file orders
- 25 Python tests for the data generator
- Luacheck: 0 warnings / 0 errors in 72 files
- `## Version: 1.13.0`, `## Interface: 120100`
- The generator reproduces `QuickRoute/Data/FlightPoints.lua` byte for byte

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
