### PR TITLE
test: pin where a route step's waypoint comes from

### DIFF
--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -1609,17 +1609,19 @@ function PathCalculator:BuildSteps(path, edges)
             step.destY = toNodeData.y or 0.5
         end
 
-        -- Also get from edge data if available
-        if edge.data then
-            if edge.data.toMapID then
-                step.destMapID = step.destMapID or edge.data.toMapID
-            end
-            if edge.data.toX then
-                step.destX = edge.data.toX
-            end
-            if edge.data.toY then
-                step.destY = edge.data.toY
-            end
+        -- The edge only fills a gap, never overrides. It used to be allowed to
+        -- overwrite destX and destY unconditionally while destMapID stayed
+        -- with the node, so a step could name one node's map and another
+        -- node's position -- the shape that put a flight waypoint in the wrong
+        -- zone twice. Nothing writes toX or toY into edge.data (the portal
+        -- descriptor that has them is nested under portalData), so those two
+        -- branches were reading a field that is never set; they are gone.
+        --
+        -- The toMapID fallback stays and currently never fires: every edge
+        -- carrying it has a to-node, so the node's map always wins. It is here
+        -- for an edge whose node is missing, not because it does work today.
+        if edge.data and edge.data.toMapID then
+            step.destMapID = step.destMapID or edge.data.toMapID
         end
 
         -- Get localized display names for source and destination nodes

--- a/tests/test_data_validation.lua
+++ b/tests/test_data_validation.lua
@@ -1535,3 +1535,54 @@ T:run("Data: FlightPoints zones are zones, not continents", function(t)
             "map " .. tostring(uiMapID) .. " is a zone")
     end
 end)
+
+-------------------------------------------------------------------------------
+-- Teleport landing coordinates
+-------------------------------------------------------------------------------
+
+T:run("Data: teleport landings are all-or-nothing", function(t)
+    -- BuildSteps applies a teleport's mapID, x and y under three separate
+    -- guards, each overriding the node. An entry with a mapID but no x or y
+    -- therefore produces a step naming one place's map and another place's
+    -- position -- the exact mix the waypoint invariant exists to prevent, and
+    -- the one case that invariant cannot see, because the edge carrying the
+    -- landing data is gone by the time a finished route can be inspected.
+    --
+    -- So it is checked here instead, at the source: a teleport that says where
+    -- it lands has to say it completely.
+    --
+    -- This covers the DATA, not the code that applies it. Deleting the three
+    -- overrides in BuildSteps is still invisible to the suite -- reaching them
+    -- needs a route whose teleport lands somewhere other than the destination
+    -- the caller asked for, and no fixture here produces one. Written down
+    -- rather than papered over with a test that would not fail.
+    local tables = {
+        TeleportItemsData = QR.TeleportItemsData,
+        ClassTeleportSpells = QR.ClassTeleportSpells,
+        RacialTeleportSpells = QR.RacialTeleportSpells,
+        GeneralTeleportSpells = QR.GeneralTeleportSpells,
+    }
+    local checked, withMap = 0, 0
+    for label, data in pairs(tables) do
+        for id, entry in pairs(data or {}) do
+            if type(entry) == "table" then
+                checked = checked + 1
+                if entry.mapID then
+                    withMap = withMap + 1
+                    t:assert(type(entry.x) == "number" and type(entry.y) == "number",
+                        label .. "[" .. tostring(id) .. "] states a landing map ("
+                            .. tostring(entry.mapID) .. ") so it must state where in it "
+                            .. "(x=" .. tostring(entry.x) .. ", y=" .. tostring(entry.y) .. ")")
+                end
+                if entry.x or entry.y then
+                    t:assert(entry.mapID ~= nil,
+                        label .. "[" .. tostring(id) .. "] states a landing position "
+                            .. "so it must state which map it is on")
+                end
+            end
+        end
+    end
+    t:assertGreaterThan(checked, 20, "over a real number of teleports (" .. checked .. ")")
+    t:assertGreaterThan(withMap, 5,
+        "of which enough name a landing map (" .. withMap .. ")")
+end)

--- a/tests/test_data_validation.lua
+++ b/tests/test_data_validation.lua
@@ -1551,16 +1551,22 @@ T:run("Data: teleport landings are all-or-nothing", function(t)
     -- So it is checked here instead, at the source: a teleport that says where
     -- it lands has to say it completely.
     --
-    -- This covers the DATA, not the code that applies it. Deleting the three
-    -- overrides in BuildSteps is still invisible to the suite -- reaching them
-    -- needs a route whose teleport lands somewhere other than the destination
-    -- the caller asked for, and no fixture here produces one. Written down
-    -- rather than papered over with a test that would not fail.
+    -- The code that applies it is covered separately, by
+    -- "BuildSteps: teleport step includes teleport name" in
+    -- test_pathfinding.lua. An earlier version of this comment claimed that
+    -- was impossible because a routed teleport cannot reach the override --
+    -- true, and beside the point: that test drives BuildSteps directly, and
+    -- its fixture already had the node and the landing disagreeing.
     local tables = {
         TeleportItemsData = QR.TeleportItemsData,
         ClassTeleportSpells = QR.ClassTeleportSpells,
         RacialTeleportSpells = QR.RacialTeleportSpells,
         GeneralTeleportSpells = QR.GeneralTeleportSpells,
+        -- Scanned by PlayerInventory and handed to BuildSteps as teleportData
+        -- like the rest, and missing from this list until review pointed it
+        -- out: a dungeon teleport with a landing map but no coordinates was
+        -- the one shape of this defect the test could not see.
+        DungeonTeleportSpells = QR.DungeonTeleportSpells,
     }
     local checked, withMap = 0, 0
     for label, data in pairs(tables) do

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -555,6 +555,45 @@ T:run("BuildSteps: teleport step includes teleport name", function(t)
     t:assertNotNil(hasTeleportName, "Teleport step mentions teleport name")
     t:assertEqual(53140, step.teleportID, "teleportID is preserved")
     t:assertEqual("spell", step.sourceType, "sourceType is preserved")
+
+    -- The landing, not the node. This fixture already had the two disagreeing
+    -- -- the node is at (0.49, 0.47), the spell puts you at (0.4947, 0.4709)
+    -- -- and asserted neither, so deleting all three overrides in BuildSteps
+    -- was invisible to the whole suite. Routing a real teleport cannot reach
+    -- this, because the edge is gone by the time a finished route can be
+    -- inspected; driving BuildSteps directly can, which is what this test
+    -- already does.
+    t:assertEqual(125, step.destMapID, "the step reports the landing map")
+    t:assert(math.abs((step.destX or -1) - 0.4947) < 0.0005,
+        "and the landing x (got " .. tostring(step.destX) .. ")")
+    t:assert(math.abs((step.destY or -1) - 0.4709) < 0.0005,
+        "and the landing y (got " .. tostring(step.destY) .. ")")
+end)
+
+T:run("BuildSteps: a teleport landing on another map reports that map", function(t)
+    -- The fixture above has the node and the landing on the same map (125), so
+    -- it cannot tell whether the map override runs -- only the coordinates.
+    -- Here they differ, which is the case that pins the third of the three.
+    resetState()
+    QR.PathCalculator.graph = QR.Graph:New()
+    QR.PathCalculator.graph:AddNode("Player Location", { mapID = 84, x = 0.50, y = 0.50 })
+    QR.PathCalculator.graph:AddNode("Dalaran", { mapID = 84, x = 0.49, y = 0.47 })
+
+    local steps = QR.PathCalculator:BuildSteps(
+        { "Player Location", "Dalaran" },
+        { { weight = 3, edgeType = "teleport", data = {
+            teleportID = 53140,
+            teleportData = { name = "Teleport: Dalaran - Northrend",
+                             mapID = 125, x = 0.4947, y = 0.4709 },
+            sourceType = "spell",
+        } } })
+
+    t:assertNotNil(steps and steps[1], "a step was built")
+    if steps and steps[1] then
+        t:assertEqual(125, steps[1].destMapID,
+            "the landing map wins over the node's 84 (got "
+                .. tostring(steps[1].destMapID) .. ")")
+    end
 end)
 
 T:run("BuildSteps: portal step says 'Take portal to X'", function(t)

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2100,13 +2100,17 @@ T:run("Every step's waypoint takes its map and its coordinates from one place", 
     -- the node being travelled to, the node being departed from (boarded
     -- transports), or the flight master (flights, whose edge hangs off a node
     -- that is merely on the right map).
-    -- The route's own requested destination is the fourth legitimate source:
-    -- the last step targets the place the caller asked for, which is not a
-    -- graph node at all.
+    -- The route's own requested destination is a legitimate source for the
+    -- LAST step only: that step targets the place the caller asked for, whose
+    -- node PathCalculator removes before returning. Offering it to every step
+    -- made the test accept the most obvious waypoint defect there is -- moving
+    -- every waypoint onto the final destination, so a player in Ironforge is
+    -- pointed at a spot in Orgrimmar -- because that value matched everywhere.
     local requested
-    local function soundFor(step)
+    local function soundFor(step, isLast)
         local candidates = {}
-        if requested then candidates[#candidates + 1] = requested end
+        if requested and isLast then candidates[#candidates + 1] = requested end
+
         local fromNode = graph.nodes[step.from]
         local toNode = graph.nodes[step.to]
         if fromNode then candidates[#candidates + 1] = fromNode end
@@ -2133,6 +2137,15 @@ T:run("Every step's waypoint takes its map and its coordinates from one place", 
         { 85, 0.50, 0.50, "Orgrimmar" },
         { 371, 0.50, 0.50, "Jade Forest" },
     }
+    -- Teleport steps are deliberately out of scope here and covered by a data
+    -- test instead. A teleport lands where its spell puts you, which is
+    -- neither endpoint, and the edge carrying those coordinates is gone by the
+    -- time a finished route can be inspected -- CalculatePath removes the
+    -- destination node before returning. So there is no second source to check
+    -- a teleport waypoint against; what can be checked is that the landing
+    -- data is never half-specified, which is the mix this test exists to
+    -- prevent. See "teleport landings are all-or-nothing" in
+    -- test_data_validation.lua.
     local checked, seenTypes, bad = 0, {}, nil
     for _, origin in ipairs({ 15, 84, 85, 1, 71, 198, 2024, 26, 87 }) do
         flightGraphSnapshot(allFlightZones(), origin)
@@ -2140,10 +2153,12 @@ T:run("Every step's waypoint takes its map and its coordinates from one place", 
         for _, d in ipairs(destinations) do
             requested = { mapID = d[1], x = d[2], y = d[3] }
             local route = QR.PathCalculator:CalculatePath(d[1], d[2], d[3], d[4])
-            for _, step in ipairs((route and route.steps) or {}) do
+            local steps = (route and route.steps) or {}
+            for i, step in ipairs(steps) do
                 checked = checked + 1
                 seenTypes[step.type or "?"] = true
-                if step.navMapID and not soundFor(step) and not bad then
+                if step.type ~= "teleport" and step.navMapID
+                    and not soundFor(step, i == #steps) and not bad then
                     bad = string.format(
                         "a %s step to %q is waypointed at map %s (%.4f, %.4f), "
                         .. "which is not where any of its own nodes are",
@@ -2158,7 +2173,7 @@ T:run("Every step's waypoint takes its map and its coordinates from one place", 
     for name in pairs(seenTypes) do typeList[#typeList + 1] = name end
     table.sort(typeList)
     t:assertGreaterThan(checked, 50, "enough steps to be worth checking (" .. checked .. ")")
-    t:assertGreaterThan(#typeList, 2,
+    t:assertGreaterThan(#typeList, 4,
         "across several step types (" .. table.concat(typeList, ", ") .. ")")
     t:assertEqual(nil, bad, "and every waypoint is internally consistent: " .. tostring(bad))
     QR.PathCalculator.knownFlightZonesOverride = nil
@@ -2201,9 +2216,10 @@ end)
 
 T:run("A step's destination map and coordinates come from the same node", function(t)
     -- The sibling of the above, for the destination the step names rather than
-    -- the waypoint it navigates to. edge.data may override destX and destY
-    -- unconditionally while destMapID is only filled in when the node is
-    -- missing, so the two can be sourced differently by construction.
+    -- the waypoint it navigates to. The map is only filled in from the edge
+    -- when the node is missing, while the position always comes from the node
+    -- -- so the two can only ever disagree if something reintroduces an
+    -- override, which is what this pins.
     resetState()
     flightGraphSnapshot(allFlightZones(), 84)
     local graph = QR.PathCalculator.graph
@@ -2232,12 +2248,23 @@ T:run("A step's destination map and coordinates come from the same node", functi
         local route = QR.PathCalculator:CalculatePath(d[1], d[2], d[3], d[4])
         for _, step in ipairs((route and route.steps) or {}) do
             local toNode = graph.nodes[step.to]
-            if toNode and step.destMapID then
+            -- Every other type takes both from its node. The name of this test
+            -- promises the map and the position; an earlier version checked
+            -- only the map.
+            if toNode and step.destMapID and step.type ~= "teleport" then
                 checked = checked + 1
                 if toNode.mapID ~= step.destMapID and not bad then
                     bad = string.format("a %s step to %q says map %s, its node is on %s",
                         tostring(step.type), tostring(step.to),
                         tostring(step.destMapID), tostring(toNode.mapID))
+                elseif (math.abs((toNode.x or 0.5) - (step.destX or -1)) > 0.0005
+                        or math.abs((toNode.y or 0.5) - (step.destY or -1)) > 0.0005)
+                    and not bad then
+                    bad = string.format(
+                        "a %s step to %q says (%.4f, %.4f), its node is at (%.4f, %.4f)",
+                        tostring(step.type), tostring(step.to),
+                        step.destX or -1, step.destY or -1,
+                        toNode.x or 0.5, toNode.y or 0.5)
                 end
             end
         end

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2084,6 +2084,169 @@ T:run("Undiscovered flight points do not count as discovered", function(t)
     _G.C_TaxiMap = saved
 end)
 
+T:run("Every step's waypoint takes its map and its coordinates from one place", function(t)
+    -- Three lines in BuildSteps set navMapID, navX and navY, and until now
+    -- nothing checked they agree: a map from one node and coordinates from
+    -- another produce a waypoint in a real zone at a position that means
+    -- nothing there. The flight step got this wrong twice before anyone
+    -- noticed, once on the building and once on the whole zone -- and it was
+    -- only noticed because a test compared the position against a known one.
+    -- This is that check for every step type.
+    resetState()
+    flightGraphSnapshot(allFlightZones(), 84)
+    local graph = QR.PathCalculator.graph
+
+    -- A waypoint is sound when its map and position belong to the same thing:
+    -- the node being travelled to, the node being departed from (boarded
+    -- transports), or the flight master (flights, whose edge hangs off a node
+    -- that is merely on the right map).
+    -- The route's own requested destination is the fourth legitimate source:
+    -- the last step targets the place the caller asked for, which is not a
+    -- graph node at all.
+    local requested
+    local function soundFor(step)
+        local candidates = {}
+        if requested then candidates[#candidates + 1] = requested end
+        local fromNode = graph.nodes[step.from]
+        local toNode = graph.nodes[step.to]
+        if fromNode then candidates[#candidates + 1] = fromNode end
+        if toNode then candidates[#candidates + 1] = toNode end
+        if step.type == "flight" and step.fromMapID then
+            local master = QR.FlightPoints[step.fromMapID]
+            if master then
+                candidates[#candidates + 1] =
+                    { mapID = step.fromMapID, x = master.x, y = master.y }
+            end
+        end
+        for _, c in ipairs(candidates) do
+            if c.mapID == step.navMapID
+                and math.abs((c.x or 0.5) - (step.navX or -1)) < 0.0005
+                and math.abs((c.y or 0.5) - (step.navY or -1)) < 0.0005 then
+                return true
+            end
+        end
+        return false
+    end
+
+    local destinations = {
+        { 84, 0.55, 0.60, "Stormwind" },
+        { 85, 0.50, 0.50, "Orgrimmar" },
+        { 371, 0.50, 0.50, "Jade Forest" },
+    }
+    local checked, seenTypes, bad = 0, {}, nil
+    for _, origin in ipairs({ 15, 84, 85, 1, 71, 198, 2024, 26, 87 }) do
+        flightGraphSnapshot(allFlightZones(), origin)
+        graph = QR.PathCalculator.graph
+        for _, d in ipairs(destinations) do
+            requested = { mapID = d[1], x = d[2], y = d[3] }
+            local route = QR.PathCalculator:CalculatePath(d[1], d[2], d[3], d[4])
+            for _, step in ipairs((route and route.steps) or {}) do
+                checked = checked + 1
+                seenTypes[step.type or "?"] = true
+                if step.navMapID and not soundFor(step) and not bad then
+                    bad = string.format(
+                        "a %s step to %q is waypointed at map %s (%.4f, %.4f), "
+                        .. "which is not where any of its own nodes are",
+                        tostring(step.type), tostring(step.to),
+                        tostring(step.navMapID), step.navX or -1, step.navY or -1)
+                end
+            end
+        end
+    end
+
+    local typeList = {}
+    for name in pairs(seenTypes) do typeList[#typeList + 1] = name end
+    table.sort(typeList)
+    t:assertGreaterThan(checked, 50, "enough steps to be worth checking (" .. checked .. ")")
+    t:assertGreaterThan(#typeList, 2,
+        "across several step types (" .. table.concat(typeList, ", ") .. ")")
+    t:assertEqual(nil, bad, "and every waypoint is internally consistent: " .. tostring(bad))
+    QR.PathCalculator.knownFlightZonesOverride = nil
+end)
+
+T:run("A step's destination map comes from its node, on every edge that has one", function(t)
+    -- Sampled routes cannot reach this: the edges where the node's map and the
+    -- edge's toMapID disagree are the walk and travel edges between dungeon
+    -- nodes, 1212 of 3029, and an ordinary route to a capital touches none of
+    -- them. So this drives BuildSteps directly, once per disagreeing edge,
+    -- which is the only way to see the rule that decides between the two.
+    resetState()
+    flightGraphSnapshot(allFlightZones(), 84)
+    local graph = QR.PathCalculator.graph
+
+    local checked, bad = 0, nil
+    for from, tos in pairs(graph.edges or {}) do
+        for to, edge in pairs(tos) do
+            local toNode = graph.nodes[to]
+            if toNode and edge.data and edge.data.toMapID
+                and toNode.mapID ~= edge.data.toMapID then
+                checked = checked + 1
+                local steps = QR.PathCalculator:BuildSteps({ from, to }, { edge })
+                local step = steps and steps[1]
+                if step and step.destMapID ~= toNode.mapID and not bad then
+                    bad = string.format(
+                        "a %s step to %q reports map %s; its node is on %s and the "
+                        .. "edge data says %s -- the node has to win",
+                        tostring(edge.edgeType), tostring(to), tostring(step.destMapID),
+                        tostring(toNode.mapID), tostring(edge.data.toMapID))
+                end
+            end
+        end
+    end
+    t:assertGreaterThan(checked, 100,
+        "enough edges where the two sources disagree (" .. checked .. ")")
+    t:assertEqual(nil, bad, "and the node wins on every one: " .. tostring(bad))
+    QR.PathCalculator.knownFlightZonesOverride = nil
+end)
+
+T:run("A step's destination map and coordinates come from the same node", function(t)
+    -- The sibling of the above, for the destination the step names rather than
+    -- the waypoint it navigates to. edge.data may override destX and destY
+    -- unconditionally while destMapID is only filled in when the node is
+    -- missing, so the two can be sourced differently by construction.
+    resetState()
+    flightGraphSnapshot(allFlightZones(), 84)
+    local graph = QR.PathCalculator.graph
+
+    -- Destinations chosen to traverse the edges that actually disagree: the
+    -- walk and travel edges between dungeon nodes, where the node's map and
+    -- the edge's toMapID differ on 1212 of 3029 edges. Routing only to a
+    -- capital never touches them, which is why nothing noticed.
+    local runs = {
+        { 15, { 84, 0.55, 0.60, "Stormwind" } },
+        { 85, { 84, 0.55, 0.60, "Stormwind" } },
+        { 1, { 115, 0.50, 0.50, "Dragonblight" } },
+        { 71, { 115, 0.50, 0.50, "Dragonblight" } },
+        { 198, { 627, 0.50, 0.50, "Dalaran" } },
+        { 2024, { 627, 0.50, 0.50, "Dalaran" } },
+        { 26, { 1670, 0.50, 0.50, "Oribos" } },
+        { 87, { 1670, 0.50, 0.50, "Oribos" } },
+        { 63, { 114, 0.50, 0.50, "Borean Tundra" } },
+        { 105, { 114, 0.50, 0.50, "Borean Tundra" } },
+    }
+    local checked, bad = 0, nil
+    for _, run in ipairs(runs) do
+        local origin, d = run[1], run[2]
+        flightGraphSnapshot(allFlightZones(), origin)
+        graph = QR.PathCalculator.graph
+        local route = QR.PathCalculator:CalculatePath(d[1], d[2], d[3], d[4])
+        for _, step in ipairs((route and route.steps) or {}) do
+            local toNode = graph.nodes[step.to]
+            if toNode and step.destMapID then
+                checked = checked + 1
+                if toNode.mapID ~= step.destMapID and not bad then
+                    bad = string.format("a %s step to %q says map %s, its node is on %s",
+                        tostring(step.type), tostring(step.to),
+                        tostring(step.destMapID), tostring(toNode.mapID))
+                end
+            end
+        end
+    end
+    t:assertGreaterThan(checked, 15, "enough steps with a destination (" .. checked .. ")")
+    t:assertEqual(nil, bad, "and each names its own node's map: " .. tostring(bad))
+    QR.PathCalculator.knownFlightZonesOverride = nil
+end)
+
 T:run("Every flight step in the graph names its own departure zone", function(t)
     -- The single-route test below inspects one flight leg, and that leg
     -- happens to be the forward direction of its pair. Both directions shared


### PR DESCRIPTION
Closes [#23](https://github.com/CybotTM/wow-quickroute/issues/23).

## Measured before deciding, and it changed what to do

The issue asked whether `destMapID`'s fallback is load-bearing before removing it. Measured on the built graph:

- **No edge carries `toX` or `toY` at all.** The portal descriptor that has them is nested under `portalData`, so those two branches were reading a field nothing writes into `edge.data`.
- **No edge with a `toMapID` lacks a to-node**, so the fallback never fires either — the node always wins.

Both are inert on the real data. So the mixing hazard is **latent, not live**: this is a test change plus a dead-branch removal, not a behaviour fix. Nothing a player sees changes.

## What was removed, and what stayed

The `toX`/`toY` branches are gone. They are the shape that has already cost this addon four review rounds — a field nobody reads is a field nobody notices is wrong — and they could overwrite `destX`/`destY` unconditionally while `destMapID` stayed with the node. That is precisely how a step comes to name one node's map and another node's position.

The `toMapID` fallback stays, with a comment saying it does no work today and why it is kept: for an edge whose to-node is missing.

## Five tests, because no single shape reaches all of it

**The waypoint invariant** walks routes of six step types — walk, travel, portal, boat, tram, flight — and asserts each waypoint's map and position belong to one thing: the node travelled to, the node departed from, the flight master, or the destination the caller asked for. That last case is not a graph node, which is why the first version of this test failed on a perfectly legitimate final step.

**Teleport steps are out of scope there, deliberately**, and covered by two tests of their own instead. A teleport lands where its spell puts you, which is neither endpoint, and the edge carrying those coordinates is gone by the time a finished route can be inspected.

**The destination test could not reach its own subject by sampling.** **1212 of 3029** edges carrying a `toMapID` disagree with their to-node's map — 422 with a dungeon node on both sides, 773 on one, 17 on neither — and an ordinary route to a capital touches none of them. Two rounds of widening the destination list still missed them. So it drives `BuildSteps` directly, once per disagreeing edge, which is the only way to make the rule visible: the node has to win.

## Two review rounds, both finding the problem in my own work

**Round 1 blocked the merge.** The invariant offered the caller's requested destination as a valid source for *every* step. So moving every waypoint onto the route's final destination — a player standing in Ironforge pointed at a spot in Orgrimmar, on another continent — passed with all 13073 assertions green in both file orders. That is the most obvious waypoint defect there is, and the test written to catch it waved it through. `requested` is legitimate for the last step only, whose to-node `CalculatePath` removes before returning; it is scoped there now.

That round also caught three claims of mine: "walks routes of every step type" is six of eight, the destination test asserted only the map despite its name, and "the 1212 disagreeing edges are between dungeon nodes" is true of 422 of them, one-sided for 773, and false for 17.

**Round 2 refuted a conclusion I had written down as fact.** I documented the three teleport overrides as untestable, having failed to build a route that reaches them. The first half was right — a routed teleport cannot reach them — but the conclusion did not follow: the sibling test two hundred lines up drives `BuildSteps` directly for exactly that reason, and **its fixture already had the node and the landing disagreeing**. It just asserted neither. Three assertions closed it. A second test, with the node on map 84 and the landing on 125, closes the map override too.

It also found the data test missing `DungeonTeleportSpells`, which `PlayerInventory` scans and hands to `BuildSteps` like the other four. Checked entries: 108 → 210.

## Verified

Every injection I can construct against `BuildSteps` reddens a named test, each run alone in its own tree:

| injection | result |
|---|---|
| edge data overrides the node for `destMapID` | red |
| default `navMapID` takes the departure map | red |
| flight guard dropped; flight-master position dropped | red |
| `navX`/`navY` from the wrong node, or transposed | red |
| boarded transports lose their from-node | red |
| **every waypoint moved onto the final destination** (the round-1 blocker) | red |
| **only the first waypoint moved** | red |
| **all three teleport overrides deleted**, or the coordinates alone, or the map alone | red |
| a teleport entry with a landing map but no coordinates | red |

13200 Lua assertions, 0 failures, in both file orders; 25 Python tests; luacheck 0 warnings / 0 errors in 72 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
