### PR TITLE
chore: release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-31
+
 ### Fixed
 - Flight routes use your own faction's flight masters. 74 of the 141 flight zones were represented by a node only one side can reach, and 45 of those had a master for the other faction that the data was discarding — The Hinterlands sent Horde players to Aerie Peak, Ashenvale to Astranaar. Zones with no master for your faction no longer get a flight edge at all.
 

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Shows the shortest path to your destination using teleports and portals
 ## Author: Sebastian Mendel
-## Version: 1.13.0
+## Version: 1.14.0
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.14.0 from [#25](https://github.com/CybotTM/wow-quickroute/pull/25) and [#26](https://github.com/CybotTM/wow-quickroute/pull/26). Two files: the TOC's `## Version` field, the addon's only version surface, and the `[Unreleased]` heading, which becomes `[1.14.0] - 2026-08-31`.

Minor rather than patch, because the faction fix changes which flight master a route sends you to — behaviour a player will notice, not an internal correction.

## What it carries

**Fixed** — flight routes use your own faction's flight masters, closing [#22](https://github.com/CybotTM/wow-quickroute/issues/22). 74 of the 141 flight zones were represented by a node only one side can walk up to, and 45 of those had a master for the other faction that the data was discarding. The Hinterlands sent Horde players to Aerie Peak (Alliance) instead of Revantusk Village; Ashenvale to Astranaar instead of Splintertree Post. Zones with no master for your faction — 17 Alliance-only, 12 Horde-only — no longer get a flight edge at all.

Measured per faction: Alliance 129 usable zones and 473 flight edges, Horde 124 and 417, a character of neither faction all 141 and 479.

**Internal** — [#23](https://github.com/CybotTM/wow-quickroute/issues/23) pinned where a route step's waypoint takes its map and its coordinates from, and removed two branches of `BuildSteps` that read a field nothing writes. No player-visible change; it exists so the next waypoint defect fails a test instead of shipping.

## Still open

- [#21](https://github.com/CybotTM/wow-quickroute/issues/21), [#5](https://github.com/CybotTM/wow-quickroute/issues/5), [#3](https://github.com/CybotTM/wow-quickroute/issues/3) — each needs one person standing in one place with `/qrverifymap`. Portal destinations, Zen Pilgrimage's landing map, and whether the Darnassus and Undercity services still exist are not derivable from the client's data files.
- [#27](https://github.com/CybotTM/wow-quickroute/issues/27) — a pandaren who picks a side keeps the faction they logged in with.
- [#28](https://github.com/CybotTM/wow-quickroute/issues/28) — overlapping zone boxes drop Rebel Camp, and `AddZoneNodes` uses the opposite faction rule from `FlightPointFor`.

## Verified on this branch

- 13630 Lua assertions, 0 failures, in both file orders
- 34 Python tests for the data generator
- Luacheck: 0 warnings / 0 errors in 72 files
- `## Version: 1.14.0`, `## Interface: 120100`
- The generator reproduces `QuickRoute/Data/FlightPoints.lua` byte for byte

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
