### PR TITLE
fix: a pandaren who picks a side is routed as that side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- A pandaren who picks a faction is routed as that faction straight away. The addon read the faction once and kept the answer, so a character who chose Horde was routed as neutral until the next reload.
+
 ## [1.14.0] - 2026-08-31
 
 ### Fixed

--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -274,6 +274,10 @@ function PathCalculator:BuildGraph()
 
     -- Only mark clean if all steps succeeded
     self.graphDirty = not buildSuccess
+    -- Remembered so CalculatePath can notice a faction change. Recorded even
+    -- on a failed build: a half-built graph belongs to the faction it was
+    -- attempted for.
+    self.graphFaction = QR.PlayerInfo and QR.PlayerInfo:GetFaction()
 
     -- Log graph stats
     local nodeCount, edgeCount = 0, 0
@@ -607,7 +611,17 @@ end
 -- @param destY number The destination Y coordinate (0-1)
 -- @return table|nil {path, totalTime, edges, steps} or nil if no path found
 function PathCalculator:CalculatePath(destMapID, destX, destY, destTitle)
-    -- Rebuild graph if needed
+    -- Rebuild graph if needed. Faction is part of "needed": AddZoneNodes and
+    -- AddFlightEdges both read it at build time, so a graph built before a
+    -- pandaren picked a side describes the wrong character. Nothing else can
+    -- change faction mid-session, so this comparison is free the rest of the
+    -- time.
+    local faction = QR.PlayerInfo and QR.PlayerInfo:GetFaction()
+    if self.graph and self.graphFaction and faction and self.graphFaction ~= faction then
+        QR:Debug("PathCalculator: faction changed from " .. tostring(self.graphFaction)
+            .. " to " .. tostring(faction) .. ", rebuilding the graph")
+        self.graphDirty = true
+    end
     if self.graphDirty or not self.graph then
         self:BuildGraph()
     end

--- a/QuickRoute/Utils/PlayerInfo.lua
+++ b/QuickRoute/Utils/PlayerInfo.lua
@@ -25,12 +25,24 @@ local cachedHasEngineering = nil
 -- Engineering skill line ID (works for all locales)
 local ENGINEERING_SKILL_LINE_ID = 202
 
---- Get player faction as "Alliance" or "Horde" (cached)
--- @return string "Alliance" or "Horde"
+--- Get player faction as "Alliance", "Horde" or "Neutral" (cached, with one
+--- exception).
+--
+-- "Neutral" is the only value that can change while the player is logged in: a
+-- pandaren begins neutral and picks a side at the end of the starting
+-- experience. So it is deliberately not cached, and every other value is,
+-- exactly as before. That needs no event registration and no guess at which
+-- event fires -- which matters, because the addon registers no faction events
+-- and nothing in it ever called InvalidateCache.
+--
+-- Without this a pandaren who chose Horde kept "Neutral" for the rest of the
+-- session, and every faction-gated decision was made for the wrong character.
+-- @return string "Alliance", "Horde" or "Neutral"
 function PlayerInfo:GetFaction()
-    if not cachedFaction then
-        cachedFaction = UnitFactionGroup("player") or "Alliance"
+    if cachedFaction and cachedFaction ~= "Neutral" then
+        return cachedFaction
     end
+    cachedFaction = UnitFactionGroup("player") or "Alliance"
     return cachedFaction
 end
 

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2321,6 +2321,64 @@ T:run("A step's destination map and coordinates come from the same node", functi
     QR.PathCalculator.knownFlightZonesOverride = nil
 end)
 
+T:run("Choosing a side mid-session takes effect without a reload", function(t)
+    -- A pandaren begins neutral and picks a faction at the end of the starting
+    -- experience. GetFaction cached the first answer forever and nothing in
+    -- the addon ever called InvalidateCache, so the rest of the session was
+    -- routed for a character who no longer existed.
+    resetState()
+    MockWoW.config.playerFaction = "Neutral"
+    QR.PlayerInfo:InvalidateCache()
+    t:assertEqual("Neutral", QR.PlayerInfo:GetFaction(), "starts neutral")
+
+    -- Build a graph as the neutral character, then choose a side. Nothing
+    -- clears the cache and nothing marks the graph dirty -- the fix has to
+    -- notice on its own.
+    flightGraphSnapshot(allFlightZones(), 84)
+    local neutralPoint = QR.PathCalculator:FlightPointFor(26)
+    MockWoW.config.playerFaction = "Horde"
+
+    t:assertEqual("Horde", QR.PlayerInfo:GetFaction(),
+        "the new faction is seen without an explicit cache clear")
+    local hordePoint = QR.PathCalculator:FlightPointFor(26)
+    t:assertNotNil(hordePoint, "The Hinterlands still has a master for them")
+    if neutralPoint and hordePoint then
+        t:assertEqual("Horde", hordePoint.faction,
+            "and it is the Horde one (got " .. tostring(hordePoint.node) .. ")")
+        t:assert(hordePoint.node ~= neutralPoint.node,
+            "which is not the one they were shown as a neutral ("
+                .. tostring(neutralPoint.node) .. ")")
+    end
+
+    -- And the graph itself, not just the accessor.
+    local route = QR.PathCalculator:CalculatePath(84, 0.55, 0.60, "Stormwind")
+    t:assertNotNil(route, "a route still exists after the change")
+    t:assertEqual("Horde", QR.PathCalculator.graphFaction,
+        "and the graph was rebuilt for the new faction")
+
+    MockWoW.config.playerFaction = "Alliance"
+    QR.PlayerInfo:InvalidateCache()
+    QR.PathCalculator.knownFlightZonesOverride = nil
+end)
+
+T:run("A settled faction is still cached", function(t)
+    -- The fix must not turn every faction read into an API call. Only
+    -- "Neutral" is re-read; Alliance and Horde stay cached exactly as before.
+    resetState()
+    MockWoW.config.playerFaction = "Horde"
+    QR.PlayerInfo:InvalidateCache()
+    t:assertEqual("Horde", QR.PlayerInfo:GetFaction(), "reads Horde")
+
+    -- Change the underlying value WITHOUT clearing the cache. A settled
+    -- faction cannot change in game, so the cached answer must survive.
+    MockWoW.config.playerFaction = "Alliance"
+    t:assertEqual("Horde", QR.PlayerInfo:GetFaction(),
+        "and keeps it, because a chosen faction never changes")
+
+    MockWoW.config.playerFaction = "Alliance"
+    QR.PlayerInfo:InvalidateCache()
+end)
+
 T:run("A character of neither faction keeps the whole flight network", function(t)
     -- UnitFactionGroup returns "Neutral" for a pandaren who has not picked a
     -- side. The first version of the accessor tested `not faction`, which can


### PR DESCRIPTION
Closes [#27](https://github.com/CybotTM/wow-quickroute/issues/27).

## The one character whose faction changes

`GetFaction` cached its first answer and nothing ever cleared it — the addon registers no faction events, and no shipped code called `InvalidateCache`. For every character that is correct: faction is fixed for the life of the account.

Except for a pandaren, who begins neutral and chooses at the end of the starting experience. They kept `"Neutral"` for the rest of the session, and every faction-gated decision was made for a character who no longer existed.

## No event needed, which is the point

The issue suggested hooking a faction-change event, and flagged that the event name could not be verified offline. It does not need one. **`"Neutral"` is the only value that can change**, so it is the only one not cached. Alliance and Horde are cached exactly as before.

A test pins that half too: changing the underlying value *without* clearing the cache must **not** be picked up, because a chosen faction cannot change. Dropping the cache entirely fails it.

## The graph needed the same treatment

`AddZoneNodes` and `AddFlightEdges` both read the faction at build time, so a graph built before the choice describes the wrong character even once the cache is right. `CalculatePath` now compares the faction the graph was built for against the current one and rebuilds on a mismatch. Nothing else can change faction mid-session, so the comparison costs nothing the rest of the time.

## This also settles half of [#28](https://github.com/CybotTM/wow-quickroute/issues/28)

`AddZoneNodes` and `FlightPointFor` disagree about a character of neither faction — one withholds the faction capitals, the other filters nothing. With the faction updating the moment it is chosen, a neutral character only exists on the starting island, where neither rule reaches anything. The disagreement stays in the code and stops being observable.

## Verified

| injection | result |
|---|---|
| pin `"Neutral"` again (the original bug) | red |
| drop the cache entirely, so every read hits the API | red |
| do not rebuild the graph on a faction change | red |
| never record which faction the graph was built for | red |

13639 Lua assertions, 0 failures, in both file orders; 34 Python tests; luacheck 0 warnings / 0 errors in 72 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
