### PR TITLE
chore: release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-08-31
+
 ### Fixed
 - A pandaren who picks a faction is routed as that faction straight away. The addon read the faction once and kept the answer, so a character who chose Horde was routed as neutral until the next reload.
 - Flight masters are filed under the zone their own name states. Zone boxes overlap, and picking the smallest containing one put 185 of them in a neighbouring zone — Darkshire under Deadwind Pass, New Kargath under Searing Gorge, Ratchet under Valley of Trials. Six more zones have a flight master as a result, nine gain a faction's access, and none loses any.

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Shows the shortest path to your destination using teleports and portals
 ## Author: Sebastian Mendel
-## Version: 1.14.0
+## Version: 1.15.0
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.15.0 from [#30](https://github.com/CybotTM/wow-quickroute/pull/30) and [#31](https://github.com/CybotTM/wow-quickroute/pull/31). Two files: the TOC's `## Version` field, the addon's only version surface, and the `[Unreleased]` heading, which becomes `[1.15.0] - 2026-08-31`.

Minor rather than patch: both entries change where a route sends you.

## What it carries

**Fixed** — a pandaren who picks a faction is routed as that faction straight away, closing [#27](https://github.com/CybotTM/wow-quickroute/issues/27). The addon read the faction once and kept the answer forever; a character who chose Horde stayed "neutral" until the next reload, and every faction-gated decision was made for a character who no longer existed. `"Neutral"` is now the only value not cached — it is the only one that can change — so this needs no event registration and no assumption about which event fires.

**Fixed** — flight masters are filed under the zone their own name states, part of [#28](https://github.com/CybotTM/wow-quickroute/issues/28). Zone boxes overlap, and picking the smallest containing one put 185 masters in a neighbouring zone: Darkshire under Deadwind Pass, New Kargath under Searing Gorge, Ratchet under Valley of Trials. Six more zones have a flight master as a result, nine gain a faction's access, and none loses any.

Measured across every zone-to-Stormwind route for both factions: 15 routes faster, 7 slower, none lost.

## Still open

- [#5](https://github.com/CybotTM/wow-quickroute/issues/5), [#3](https://github.com/CybotTM/wow-quickroute/issues/3), [#21](https://github.com/CybotTM/wow-quickroute/issues/21) — each needs one person standing in one place with `/qrverifymap`. The data is not in the client's exported tables: `SpellTargetPosition` is not published, and whether an NPC still stands in Darnassus is not recorded anywhere a script can read.
- [#28](https://github.com/CybotTM/wow-quickroute/issues/28) stays open for its other half. Rebel Camp still gives Northern Stranglethorn no Alliance master — it lands on the pre-Cataclysm "Stranglethorn Vale" map, which has no graph node, so the entry is inert rather than harmful.

## Verified on this branch

- 13569 Lua assertions, 0 failures, in both file orders
- 37 Python tests for the data generator
- Luacheck: 0 warnings / 0 errors in 72 files
- `## Version: 1.15.0`, `## Interface: 120100`
- The generator reproduces `QuickRoute/Data/FlightPoints.lua` byte for byte

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
