### PR TITLE
fix: Zen Pilgrimage lands in Kun-Lai Summit, not Karazhan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Zen Pilgrimage sends Monks to Kun-Lai Summit, where it actually lands. It pointed at a Karazhan instance floor on another continent, and now carries the landing position rather than the middle of the zone.
+
 ## [1.15.0] - 2026-08-31
 
 ### Fixed

--- a/QuickRoute/Data/TeleportItems.lua
+++ b/QuickRoute/Data/TeleportItems.lua
@@ -1100,10 +1100,19 @@ QR.ClassTeleportSpells = {
     -- Monk
     [126892] = {
         name = "Zen Pilgrimage",
-        destination = "Peak of Serenity / Temple of Five Dawns",
-        mapID = 809,  -- Peak of Serenity
-        x = 0.5000,
-        y = 0.5000,
+        destination = "Peak of Serenity",
+        -- Verified in game on 2026-08-31 with /qrverifymap immediately after
+        -- casting: the client reports 379 Kun-Lai Summit <- 424 Pandaria, at
+        -- (0.4864, 0.4294). It was 809, which is a Karazhan instance floor
+        -- whose parent is Deadwind Pass -- a different continent.
+        --
+        -- The Peak of Serenity has no UiMap of its own; it is a place inside
+        -- Kun-Lai Summit, which is why there was nothing to match by name and
+        -- the wrong ID went unnoticed. The coordinates are the landing spot,
+        -- not the zone centre they used to be.
+        mapID = 379,
+        x = 0.4864,
+        y = 0.4294,
         cooldown = 60,
         type = QR.TeleportTypes.SPELL,
         faction = "both",

--- a/tests/test_data_validation.lua
+++ b/tests/test_data_validation.lua
@@ -1623,3 +1623,64 @@ T:run("Data: teleport landings are all-or-nothing", function(t)
     t:assertGreaterThan(withMap, 5,
         "of which enough name a landing map (" .. withMap .. ")")
 end)
+
+-------------------------------------------------------------------------------
+-- Teleport destination maps
+-------------------------------------------------------------------------------
+
+T:run("Data: every teleport lands on a map the addon knows", function(t)
+    -- Zen Pilgrimage pointed at map 809 for as long as this data existed. 809
+    -- is a Karazhan instance floor whose parent is Deadwind Pass -- a
+    -- different continent from where the spell actually lands. Nothing caught
+    -- it because nothing asked whether the destination was a map the addon has
+    -- any other knowledge of, and the Peak of Serenity has no map of its own
+    -- to match by name.
+    --
+    -- A destination the addon knows nothing about is not automatically wrong,
+    -- but it should be a decision rather than an accident. The exceptions are
+    -- listed here with a reason; everything else has to resolve to a continent
+    -- or have adjacency data.
+    local ALLOWED_UNKNOWN = {
+        -- Emerald Dreamway, UiMap type 6: a druid-only hub that is not a zone
+        -- and has no continent, so it cannot appear in the zone tables.
+        [715] = "Dreamwalk",
+    }
+    local sources = {
+        TeleportItemsData = QR.TeleportItemsData,
+        ClassTeleportSpells = QR.ClassTeleportSpells,
+        RacialTeleportSpells = QR.RacialTeleportSpells,
+        GeneralTeleportSpells = QR.GeneralTeleportSpells,
+        DungeonTeleportSpells = QR.DungeonTeleportSpells,
+    }
+    local checked = 0
+    for label, tbl in pairs(sources) do
+        for id, entry in pairs(tbl or {}) do
+            if type(entry) == "table" and entry.mapID then
+                checked = checked + 1
+                local continent = QR.GetContinentForZone and QR.GetContinentForZone(entry.mapID)
+                local adjacent = QR.GetAdjacentZones and QR.GetAdjacentZones(entry.mapID)
+                local known = continent ~= nil or (adjacent and #adjacent > 0)
+                t:assert(known or ALLOWED_UNKNOWN[entry.mapID] ~= nil,
+                    label .. "[" .. tostring(id) .. "] (" .. tostring(entry.name)
+                        .. ") lands on map " .. tostring(entry.mapID)
+                        .. ", which the addon has no continent or adjacency for")
+            end
+        end
+    end
+    t:assertGreaterThan(checked, 50,
+        "over a real number of teleports (" .. checked .. ")")
+end)
+
+T:run("Data: Zen Pilgrimage lands where the client says it does", function(t)
+    -- Verified in game on 2026-08-31 with /qrverifymap immediately after the
+    -- cast: 379 Kun-Lai Summit <- 424 Pandaria, at (0.4864, 0.4294). Pinned
+    -- because the previous value survived every other check in this file.
+    local entry = QR.ClassTeleportSpells and QR.ClassTeleportSpells[126892]
+    t:assertNotNil(entry, "Zen Pilgrimage is in the data")
+    if not entry then return end
+    t:assertEqual(379, entry.mapID, "it lands on Kun-Lai Summit")
+    t:assert(math.abs(entry.x - 0.4864) < 0.0005,
+        "at the verified x (got " .. tostring(entry.x) .. ")")
+    t:assert(math.abs(entry.y - 0.4294) < 0.0005,
+        "at the verified y (got " .. tostring(entry.y) .. ")")
+end)


### PR DESCRIPTION
Closes [#5](https://github.com/CybotTM/wow-quickroute/issues/5).

## What it was

The addon sent Monks to map **809** — a Karazhan instance floor whose parent is Deadwind Pass, a different continent from where the spell puts you.

Verified in game with `/qrverifymap` immediately after the cast:

```
client   : 379 Kun-Lai-Gipfel (type 3)  <-  424 Pandaria (type 2)  <-  947 Azeroth (type 1)
position : 0.4864, 0.4294
addon    : continent PANDARIA, 7 adjacent zone(s)
```

So: **map 379, at (0.4864, 0.4294)**. Those coordinates replace the `0.5 / 0.5` zone-centre placeholder the entry carried.

## Everything except the two numbers was derivable offline

And was, before asking — the evidence is on the issue:

- `UiMap` row 809 is `Karazhan`, `Type = 4`, parent 42 (Deadwind Pass). The reported defect was real.
- There is **no `UiMap` named "Peak of Serenity"**. It is a place inside Kun-Lai Summit, not a map, which is why there was nothing to match by name and the wrong ID went unnoticed.
- `SpellEffect` for 126892 carries `ImplicitTarget = 17`, `TARGET_DEST_DB` — the destination is a row in `SpellTargetPosition`, the one table the exports do not publish. That is why the last step needed a client.

## The test that matters is the general one

Nothing asked whether a teleport's destination was a map the addon has any *other* knowledge of. That is how 809 survived every check in the file: it is a real map, correctly formatted, just the wrong one.

Every destination must now resolve to a continent or have adjacency data, or be listed as a deliberate exception with a reason. There is exactly one exception — Dreamwalk's **Emerald Dreamway** (`UiMap` type 6), a druid hub that is not a zone and cannot appear in the zone tables.

I scanned the other four teleport tables for the same shape while I was there. The Dreamway is the only other destination the addon does not know, and it is correct.

A second test pins the verified value, because the wrong one had survived so long.

## Verified

| injection | result |
|---|---|
| `mapID` back to 809 | red — caught by the **general** test, as it should have been |
| coordinates back to the zone centre | red |
| any teleport given an unknown map | red |

13634 Lua assertions, 0 failures, in both file orders; 34 Python tests; luacheck 0 warnings / 0 errors in 72 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
