### PR TITLE
fix: stop offering services in Darnassus and Undercity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Zen Pilgrimage sends Monks to Kun-Lai Summit, where it actually lands. It pointed at a Karazhan instance floor on another continent, and now carries the landing position rather than the middle of the zone.
 - Dalaran is one place in the route graph again. Three teleports and a mage portal called their destination "Dalaran (Legion)" while the rest of the addon called the same spot "Dalaran (Broken Isles)", so anyone holding a Dalaran teleport got two nodes at identical coordinates with the portals attached to one and the teleport to the other.
+- No more routes to a bank or auction house in Darnassus or Undercity. Both cities were destroyed in Battle for Azeroth, and the maps the client still ships are the pre-destruction versions a character only reaches by asking Zidormi to send them back — so the five services the addon listed there are not standing in the present day. Both cities keep their graph nodes, because standing on those maps is possible and a character who is there needs a way out; no route changes as a result.
 
 ## [1.15.0] - 2026-08-31
 

--- a/QuickRoute/Data/ServicePOIs.lua
+++ b/QuickRoute/Data/ServicePOIs.lua
@@ -1,6 +1,14 @@
 -- ServicePOIs.lua
 -- Static coordinates for common service NPCs (Auction House, Bank, Void Storage, Crafting Table)
 -- in capital cities. Used by ServiceRouter to find nearest service via Dijkstra.
+--
+-- Darnassus (89) and Undercity (90) are deliberately absent. Both cities were
+-- destroyed in Battle for Azeroth and the maps the client still ships for them
+-- are the pre-destruction versions, reachable only by talking to Zidormi. In
+-- the default phase a character walks into a burned tree or a plague-flooded
+-- ruin, and the services below are not standing. The addon cannot tell which
+-- phase a player is in, so it does not offer them at all -- the same call this
+-- file already makes for pre-revamp Silvermoon (110). See issue #3.
 local ADDON_NAME, QR = ...
 
 QR.ServicePOIs = {
@@ -8,12 +16,10 @@ QR.ServicePOIs = {
         -- Alliance
         { mapID = 84,   x = 0.6105, y = 0.7064, faction = "Alliance" },  -- Stormwind
         { mapID = 87,   x = 0.2549, y = 0.7468, faction = "Alliance" },  -- Ironforge
-        { mapID = 89,   x = 0.5481, y = 0.5642, faction = "Alliance" },  -- Darnassus
         { mapID = 103,  x = 0.4842, y = 0.6925, faction = "Alliance" },  -- Exodar
         { mapID = 1161, x = 0.7195, y = 0.1298, faction = "Alliance" },  -- Boralus
         -- Horde
         { mapID = 85,   x = 0.5430, y = 0.6295, faction = "Horde" },     -- Orgrimmar
-        { mapID = 90,   x = 0.6617, y = 0.3707, faction = "Horde" },     -- Undercity
         { mapID = 88,   x = 0.3920, y = 0.5296, faction = "Horde" },     -- Thunder Bluff
         -- Map switched from 110 to the revamped Silvermoon 2393. Both maps
         -- exist and are both named "Silvermoon"; 2393 is the one the player
@@ -32,12 +38,10 @@ QR.ServicePOIs = {
         -- Alliance
         { mapID = 84,   x = 0.6282, y = 0.6995, faction = "Alliance" },  -- Stormwind
         { mapID = 87,   x = 0.3530, y = 0.6270, faction = "Alliance" },  -- Ironforge
-        { mapID = 89,   x = 0.4355, y = 0.3543, faction = "Alliance" },  -- Darnassus
         { mapID = 103,  x = 0.4734, y = 0.6435, faction = "Alliance" },  -- Exodar
         { mapID = 1161, x = 0.7600, y = 0.1657, faction = "Alliance" },  -- Boralus
         -- Horde
         { mapID = 85,   x = 0.5330, y = 0.6455, faction = "Horde" },     -- Orgrimmar
-        { mapID = 90,   x = 0.6397, y = 0.4865, faction = "Horde" },     -- Undercity
         { mapID = 88,   x = 0.4530, y = 0.5230, faction = "Horde" },     -- Thunder Bluff
         -- Coordinates surveyed on map 110, not re-surveyed on 2393.
         { mapID = 2393, x = 0.5780, y = 0.2190, faction = "Horde" },     -- Silvermoon
@@ -55,7 +59,6 @@ QR.ServicePOIs = {
         { mapID = 87,   x = 0.3550, y = 0.6240, faction = "Alliance" },  -- Ironforge
         -- Horde
         { mapID = 85,   x = 0.5350, y = 0.6430, faction = "Horde" },     -- Orgrimmar
-        { mapID = 90,   x = 0.6420, y = 0.4830, faction = "Horde" },     -- Undercity
         -- Neutral
         { mapID = 2112, x = 0.5730, y = 0.3420, faction = "both" },      -- Valdrakken
         { mapID = 2339, x = 0.4945, y = 0.5200, faction = "both" },      -- Dornogal

--- a/tests/test_data_validation.lua
+++ b/tests/test_data_validation.lua
@@ -1373,6 +1373,42 @@ T:run("PathCalculator: Silvermoon City uses the revamped map", function(t)
         "Silvermoon City is uiMapID 2393, not the pre-revamp 110")
 end)
 
+-- The generalisation of the Silvermoon assertion above. The client still ships
+-- maps for cities that no longer exist in the present day; a character only
+-- reaches them by asking Zidormi to send them back. Standing on one is
+-- possible, so these maps keep their graph nodes -- but the bank, auction
+-- house and void storage a player is sent to are not there in the default
+-- phase, and the addon cannot tell which phase anyone is in.
+--
+-- Each entry names why the map is past-only. Removing one from this list is a
+-- claim that the place came back.
+local PAST_ONLY_MAPS = {
+    [57]  = "Teldrassil, burned in Battle for Azeroth",
+    [89]  = "Darnassus, burned in Battle for Azeroth",
+    [90]  = "Undercity, destroyed and plagued in Battle for Azeroth",
+    [94]  = "Eversong Woods, pre-revamp version",
+    [95]  = "Ghostlands, pre-revamp version",
+    [110] = "Silvermoon, pre-revamp version, superseded by 2393",
+    [122] = "Isle of Quel'Danas, pre-revamp version",
+}
+
+T:run("ServicePOIs: no service sits on a map only reachable in the past", function(t)
+    local offenders = {}
+    for serviceType, locations in pairs(QR.ServicePOIs or {}) do
+        for _, loc in ipairs(locations) do
+            local reason = PAST_ONLY_MAPS[loc.mapID]
+            if reason then
+                offenders[#offenders + 1] = string.format(
+                    "%s on map %d (%s)", serviceType, loc.mapID, reason)
+            end
+        end
+    end
+    table.sort(offenders)
+    t:assertEqual(0, #offenders,
+        "no service is offered in a destroyed or superseded city: "
+        .. table.concat(offenders, "; "))
+end)
+
 -------------------------------------------------------------------------------
 -- FlightPoints
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Closes [#3](https://github.com/CybotTM/wow-quickroute/issues/3).

## What it was

`ServicePOIs.lua` offered an auction house and a bank in **Darnassus** (map 89), and an auction house, a bank and void storage in **Undercity** (map 90).

Both cities were destroyed in Battle for Azeroth. The maps the client still ships for them are the pre-destruction versions, and a character only reaches those by asking **Zidormi** to send them back in time — at Darkshore for Darnassus, in Tirisfal Glades for Undercity. In the default phase a player walks into a burned tree or a plague-flooded ruin. The services are not standing, and the addon has no way to tell which phase anyone is in.

That matches what the client's own tables said on the issue: of 348 zone-type `UiMap` rows only 19 carry a `VisibilityPlayerConditionID`, and 89 and 90 are two of them — the same category as pre-revamp Silvermoon (110), which this repo already deliberately avoids.

## What changed, and what deliberately did not

Five `ServicePOIs` entries are gone.

**Both cities keep their graph nodes.** Standing on those maps is possible after a Zidormi conversation, and a character who is there still needs a way out. The distinction is that a node is a *place*, which exists, while a service entry is a *claim that something is standing there*, which is what turned out to be false.

Measured before removing anything, so the claim is not a guess: **0 of 132 zone-to-capital routes pass through either city**, for both factions. Nothing in routing changes.

## The test is the generalisation of one already here

`test_data_validation.lua` already asserted that Silvermoon uses the revamped map 2393 "not the pre-revamp 110" — a single hand-written value, because that mistake had been made once. The same mistake is possible on six other maps.

The new test names all seven with the reason each is past-only (Teldrassil, Darnassus, Undercity, Eversong, Ghostlands, Silvermoon 110, Quel'Danas) and fails when any service sits on one. Removing an entry from that list is a deliberate claim that the place came back.

## Verified

| injection | result |
|---|---|
| Darnassus auction house re-added | red — `AUCTION_HOUSE on map 89 (Darnassus, burned in Battle for Azeroth)` |
| Undercity void storage re-added | red — `VOID_STORAGE on map 90 (Undercity, destroyed and plagued in Battle for Azeroth)` |

13594 Lua assertions, 0 failures, in both file orders; 37 Python tests; luacheck 0 warnings / 0 errors in 72 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
