### PR TITLE
fix: file flight masters on the map the player is actually on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- Six zones had a flight master in the data and no flight edge in the graph. The client ships a second set of zone maps that repeats zones under different IDs, and the flight-point generator was filing masters under those: Azsuna as 1187 rather than 630, Isle of Dorn as 2271 rather than 2248, and the same for Bastion, The Ringing Deeps, Hallowfall and Harandar. Five of those IDs are ones the addon's zone tables do not know at all. Azj-Kahet had two entries and keeps the right one. No route changes as a result — 0 of 1824 measured routes into those zones and 0 of 306 to the faction capitals — but the graph gains 18 flight edges that were previously attached to nothing.
+
+### Fixed
 - Teleport items you are wearing work again. Eleven of them sit in slots the inventory scan never looked at — the six guild cloaks and Mountebank's Colorful Cloak on the back, three pairs of slippers on the feet, and the Blessed Medallion of Karabor on the neck — so while worn they counted as not owned and the panel drew a plain icon with nothing behind it. The slot list is now taken from the item data instead of being kept by hand.
 - Clicking a worn teleport item no longer reports that the item was not found. The button ran `/equip` first, which searches the bags only, so aiming it at something already on the character failed on that line and never reached the teleport. An item already in its slot is now used straight from the slot.
 - Zen Pilgrimage sends Monks to Kun-Lai Summit, where it actually lands. It pointed at a Karazhan instance floor on another continent, and now carries the landing position rather than the middle of the zone.

--- a/QuickRoute/Data/FlightPoints.lua
+++ b/QuickRoute/Data/FlightPoints.lua
@@ -157,6 +157,7 @@ QR.FlightPoints = {
     [550] = { x = 0.7974, y = 0.4975, worldX = 3040.8, worldY = 4783.1, node = "The Ring of Trials, Nagrand", continentID = 1116, faction = "both" },
     [588] = { x = 0.4065, y = 0.1061, worldX = 5356.2, worldY = -3942.2, node = "Warspear, Ashran", continentID = 1116, faction = "Horde", alt = { x = 0.3739, y = 0.9090, worldX = 3685.1, worldY = -3840.5, node = "Stormshield (Alliance), Ashran", continentID = 1116, faction = "Alliance" } },
     -- world map 1220
+    [630] = { x = 0.4083, y = 0.0911, worldX = 1406.1, worldY = 7140.7, node = "Challiane's Terrace, Azsuna", continentID = 1220, faction = "both" },
     [634] = { x = 0.5200, y = 0.3467, worldX = 3835.6, worldY = 2016.1, node = "Stormtorn Foothills, Stormheim", continentID = 1220, faction = "both" },
     [641] = { x = 0.5496, y = 0.7255, worldX = 2299.9, worldY = 6577.7, node = "Lorlathil, Val'sharah", continentID = 1220, faction = "both" },
     [646] = { x = 0.4974, y = 0.2108, worldX = -545.2, worldY = 3001.8, node = "Vengeance Point, Broken Shore", continentID = 1220, faction = "both" },
@@ -164,7 +165,6 @@ QR.FlightPoints = {
     [680] = { x = 0.3423, y = 0.4944, worldX = 1615.5, worldY = 4757.9, node = "Meredil, Suramar", continentID = 1220, faction = "both" },
     [739] = { x = 0.3646, y = 0.2782, worldX = 4634.3, worldY = 5339.4, node = "Trueshot Lodge, Highmountain", continentID = 1220, faction = "both" },
     [790] = { x = 0.3825, y = 0.4592, worldX = -3362.3, worldY = 4823.0, node = "Eye of Azshara, Azsuna", continentID = 1220, faction = "both" },
-    [1187] = { x = 0.4083, y = 0.0911, worldX = 1406.1, worldY = 7140.7, node = "Challiane's Terrace, Azsuna", continentID = 1220, faction = "both" },
     -- world map 1642
     [862] = { x = 0.6623, y = 0.1767, worldX = 382.0, worldY = 104.0, node = "Nesingwary's Gameland, Zuldazar", continentID = 1642, faction = "both" },
     [863] = { x = 0.3894, y = 0.7806, worldX = 793.2, worldY = 1400.7, node = "Zul'jan, Nazmir", continentID = 1642, faction = "Horde", alt = { x = 0.3424, y = 0.6330, worldX = 1310.3, worldY = 1647.5, node = "Grimwatt's Crash, Nazmir", continentID = 1642, faction = "Alliance" } },
@@ -184,9 +184,9 @@ QR.FlightPoints = {
     [1355] = { x = 0.7420, y = 0.2495, worldX = 2077.9, worldY = -1566.3, node = "Kelya's Grave, Nazjatar", continentID = 1718, faction = "both" },
     -- world map 2222
     [1525] = { x = 0.6053, y = 0.6077, worldX = -2624.0, worldY = 6010.5, node = "Darkhaven, Revendreth", continentID = 2222, faction = "both" },
+    [1533] = { x = 0.4409, y = 0.3245, worldX = -2305.1, worldY = -4361.4, node = "Sagehaven, Bastion", continentID = 2222, faction = "both" },
     [1536] = { x = 0.4997, y = 0.5324, worldX = 2580.5, worldY = -2520.8, node = "Theater of Pain, Maldraxxus", continentID = 2222, faction = "both" },
     [1565] = { x = 0.4639, y = 0.5105, worldX = -6788.6, worldY = 1006.8, node = "Heart of the Forest, Ardenweald", continentID = 2222, faction = "both" },
-    [1569] = { x = 0.4409, y = 0.3245, worldX = -2305.1, worldY = -4361.4, node = "Sagehaven, Bastion", continentID = 2222, faction = "both" },
     -- world map 2374
     [1970] = { x = 0.3561, y = 0.6504, worldX = -4213.0, worldY = 684.6, node = "Haven, Zereth Mortis", continentID = 2374, faction = "both" },
     -- world map 2444
@@ -201,15 +201,14 @@ QR.FlightPoints = {
     -- world map 2548
     [2200] = { x = 0.5106, y = 0.6241, worldX = -1716.3, worldY = 7074.1, node = "Central Encampment, The Emerald Dream", continentID = 2548, faction = "both" },
     -- world map 2552
-    [2271] = { x = 0.3822, y = 0.7853, worldX = 985.5, worldY = -1847.6, node = "Freywold Village, Isle of Dorn", continentID = 2552, faction = "both" },
+    [2248] = { x = 0.4107, y = 0.7294, worldX = 985.5, worldY = -1847.6, node = "Freywold Village, Isle of Dorn", continentID = 2552, faction = "both" },
     [2339] = { x = 0.4476, y = 0.5104, worldX = 2585.4, worldY = -2473.3, node = "Dornogal, Isle of Dorn", continentID = 2552, faction = "both" },
     -- world map 2601
+    [2214] = { x = 0.4277, y = 0.3341, worldX = 2224.3, worldY = -2735.8, node = "Gundargaz, The Ringing Deeps", continentID = 2601, faction = "both" },
+    [2215] = { x = 0.6750, y = 0.4460, worldX = 2471.6, worldY = -1204.9, node = "Dunelle's Kindness, Hallowfall", continentID = 2601, faction = "both" },
     [2255] = { x = 0.5696, y = 0.4672, worldX = -593.3, worldY = -1446.6, node = "Weaver's Lair, Azj-Kahet", continentID = 2601, faction = "both" },
-    [2270] = { x = 0.3781, y = 0.0694, worldX = -1544.4, worldY = -590.8, node = "Wildcamp Ul'ar, Azj-Kahet", continentID = 2601, faction = "both" },
-    [2272] = { x = 0.3843, y = 0.3435, worldX = 2224.3, worldY = -2735.8, node = "Gundargaz, The Ringing Deeps", continentID = 2601, faction = "both" },
-    [2273] = { x = 0.7185, y = 0.6031, worldX = 2471.6, worldY = -1204.9, node = "Dunelle's Kindness, Hallowfall", continentID = 2601, faction = "both" },
     -- world map 2694
-    [2480] = { x = 0.6936, y = 0.5260, worldX = -128.2, worldY = -1673.3, node = "Har'athir, Harandar", continentID = 2694, faction = "both" },
+    [2413] = { x = 0.6936, y = 0.5260, worldX = -128.2, worldY = -1673.3, node = "Har'athir, Harandar", continentID = 2694, faction = "both" },
     -- world map 2706
     [2346] = { x = 0.4293, y = 0.4620, worldX = 65.6, worldY = 535.8, node = "The Incontinental Hotel", continentID = 2706, faction = "both" },
     -- world map 2735

--- a/scripts/generate_flight_points.py
+++ b/scripts/generate_flight_points.py
@@ -25,6 +25,7 @@ import re
 import sys
 
 ZONE_TYPE = "3"          # UiMap.Type 3 is a zone
+RETAIL_MAP_SYSTEM = "0"  # UiMap.System 0 is the map set the retail client uses
 MIN_NEIGHBOURS = 2       # a flight master connects to more than one node
 
 # Rows the client keeps for its own purposes. The degree filter removes most of
@@ -127,7 +128,7 @@ def build(csv_dir):
     nodes = load(csv_dir, "TaxiNodes.csv",
                  ("Name_lang", "Pos_0", "Pos_1", "ID", "ContinentID", "Flags"))
     paths = load(csv_dir, "TaxiPath.csv", ("FromTaxiNode", "ToTaxiNode"))
-    uimaps = load(csv_dir, "UiMap.csv", ("Name_lang", "ID", "Type"))
+    uimaps = load(csv_dir, "UiMap.csv", ("Name_lang", "ID", "Type", "System"))
     assignments = load(csv_dir, "UiMapAssignment.csv",
                        ("UiMapID", "MapID", "Region_0", "Region_1", "Region_3",
                         "Region_4", "UiMin_0", "UiMin_1", "UiMax_0", "UiMax_1"))
@@ -143,6 +144,20 @@ def build(csv_dir):
     for row in assignments:
         entry = uimap.get(row["UiMapID"])
         if not entry or entry["Type"] != ZONE_TYPE:
+            continue
+        # UiMap ships several map sets side by side and distinguishes them by
+        # System. The retail client uses System 0; System 2 is a parallel set
+        # that repeats zones under different IDs -- Azsuna is 630 in the game
+        # and 1187 here, Isle of Dorn 2248 and 2271, Hallowfall 2215 and 2273.
+        #
+        # Their boxes cover the same world coordinates, so they compete for
+        # every node, and where one wins the flight master is filed under an ID
+        # no player is ever on. Seven of the 147 shipped zones were: Azsuna,
+        # Bastion, Isle of Dorn, Azj-Kahet, The Ringing Deeps, Hallowfall and
+        # Harandar. Five of those seven map IDs are ones ZoneAdjacency.lua does
+        # not know at all, so those zones had a flight master in the data and no
+        # flight edge in the graph.
+        if entry.get("System") != RETAIL_MAP_SYSTEM:
             continue
         try:
             x0, y0 = float(row["Region_0"]), float(row["Region_1"])

--- a/tests/test_data_validation.lua
+++ b/tests/test_data_validation.lua
@@ -1720,3 +1720,53 @@ T:run("Data: Zen Pilgrimage lands where the client says it does", function(t)
     t:assert(math.abs(entry.y - 0.4294) < 0.0005,
         "at the verified y (got " .. tostring(entry.y) .. ")")
 end)
+
+-------------------------------------------------------------------------------
+-- FlightPoints: retail map IDs
+--
+-- UiMap ships a second map set under System 2 that repeats zones under
+-- different IDs, on boxes covering the same world coordinates. Seven of the
+-- 147 shipped flight points landed on one, and five of those IDs are ones
+-- ZoneAdjacency.lua does not know -- so the zone had a flight master in the
+-- data and no flight edge in the graph.
+--
+-- The generator filters System 2 out now, and its own tests cover that. This
+-- pins the shipped values as well, the way the Silvermoon assertion above
+-- does, because a regeneration against an older script would put them back
+-- and every other assertion in this file would still pass.
+local SYSTEM_2_MAPS = {
+    [1187] = "Azsuna, which is 630",
+    [1569] = "Bastion, which is 1533",
+    [2270] = "Azj-Kahet, which is 2255",
+    [2271] = "Isle of Dorn, which is 2248",
+    [2272] = "The Ringing Deeps, which is 2214",
+    [2273] = "Hallowfall, which is 2215",
+    [2480] = "Harandar, which is 2413",
+}
+
+T:run("Data: FlightPoints uses no System 2 duplicate map", function(t)
+    local offenders = {}
+    for uiMapID in pairs(QR.FlightPoints or {}) do
+        local why = SYSTEM_2_MAPS[uiMapID]
+        if why then
+            offenders[#offenders + 1] = string.format("%d (%s)", uiMapID, why)
+        end
+    end
+    table.sort(offenders)
+    t:assertEqual(0, #offenders,
+        "no flight point sits on a duplicate map the player is never on: "
+        .. table.concat(offenders, "; "))
+end)
+
+T:run("Data: the zones those duplicates stood in for have a flight point", function(t)
+    local expected = {630, 1533, 2214, 2215, 2248, 2255, 2413}
+    local missing = {}
+    for _, uiMapID in ipairs(expected) do
+        if not (QR.FlightPoints or {})[uiMapID] then
+            missing[#missing + 1] = tostring(uiMapID)
+        end
+    end
+    t:assertEqual(0, #missing,
+        "each zone kept its flight master on the retail map; missing: "
+        .. table.concat(missing, ", "))
+end)

--- a/tests/test_generate_flight_points.py
+++ b/tests/test_generate_flight_points.py
@@ -109,6 +109,10 @@ class FixtureMixin:
     """A minimal but complete input set, one world map, two zones."""
 
     ZONE_A, ZONE_B, ZONE_C = 100, 200, 300
+    # A System 2 duplicate of Alpha Vale. Deliberately a SMALLER box than the
+    # real one, so it wins on area and, sharing the name, corroborates too --
+    # everything the box choice ranks on. Only the System filter separates them.
+    ZONE_A_LEGACY = 400
 
     def build_inputs(self, taxi_rows, path_rows=None):
         directory = tempfile.mkdtemp()
@@ -131,11 +135,22 @@ class FixtureMixin:
         )
         write_csv(
             os.path.join(directory, "UiMap.csv"),
-            ["Name_lang", "ID", "Type"],
+            ["Name_lang", "ID", "Type", "System"],
             [
-                {"Name_lang": "Alpha Vale", "ID": str(self.ZONE_A), "Type": "3"},
-                {"Name_lang": "Beta Reach", "ID": str(self.ZONE_B), "Type": "3"},
-                {"Name_lang": "Gamma Hold", "ID": str(self.ZONE_C), "Type": "3"},
+                {"Name_lang": "Alpha Vale", "ID": str(self.ZONE_A), "Type": "3",
+                 "System": "0"},
+                {"Name_lang": "Beta Reach", "ID": str(self.ZONE_B), "Type": "3",
+                 "System": "0"},
+                {"Name_lang": "Gamma Hold", "ID": str(self.ZONE_C), "Type": "3",
+                 "System": "0"},
+                # UiMap ships a second map set under System 2 that repeats
+                # zones under different IDs. Its boxes cover the same world
+                # coordinates, so it competes for every node -- and this one is
+                # deliberately SMALLER than the Alpha Vale it duplicates, so it
+                # wins on area and corroborates on name. Without the System
+                # filter it takes every Alpha Vale node.
+                {"Name_lang": "Alpha Vale", "ID": str(self.ZONE_A_LEGACY),
+                 "Type": "3", "System": "2"},
             ],
         )
         write_csv(
@@ -163,6 +178,11 @@ class FixtureMixin:
                 {"UiMapID": str(self.ZONE_A), "MapID": "2",
                  "Region_0": "0", "Region_1": "0", "Region_3": "100", "Region_4": "100",
                  "UiMin_0": "0", "UiMin_1": "0", "UiMax_0": "1", "UiMax_1": "1"},
+                # The System 2 duplicate, covering the same ground as Alpha
+                # Vale but tighter, so it beats it on area.
+                {"UiMapID": str(self.ZONE_A_LEGACY), "MapID": "1",
+                 "Region_0": "10", "Region_1": "10", "Region_3": "90", "Region_4": "90",
+                 "UiMin_0": "0", "UiMin_1": "0", "UiMax_0": "1", "UiMax_1": "1"},
             ],
         )
         return directory
@@ -188,6 +208,43 @@ class FilterTest(FixtureMixin, unittest.TestCase):
         ])
         self.assertIn(self.ZONE_A, result)
         self.assertEqual(result[self.ZONE_A]["name"], "Havenhold, Alpha Vale")
+
+    def test_the_retail_map_wins_over_its_system_2_duplicate(self):
+        # UiMap ships a second map set under System 2 that repeats zones under
+        # different IDs, on boxes covering the same world coordinates. Seven of
+        # the 147 shipped flight points landed on one -- Azsuna as 1187 rather
+        # than 630, Isle of Dorn as 2271 rather than 2248 -- and five of those
+        # IDs are ones ZoneAdjacency.lua does not know, so the zone had a
+        # flight master in the data and no flight edge in the graph.
+        #
+        # The duplicate in the fixture beats Alpha Vale on both things the box
+        # choice ranks on: it is smaller, and it carries the same name, so it
+        # corroborates too. Only the System filter separates them.
+        result = self.resolve([
+            self.node(1, "Havenhold, Alpha Vale", 50, 50),
+            self.node(2, "Farpost, Beta Reach", 250, 250),
+            self.node(3, "Waypost, Beta Reach", 260, 260),
+        ])
+        self.assertIn(self.ZONE_A, result)
+        self.assertNotIn(self.ZONE_A_LEGACY, result)
+
+    def test_a_missing_system_column_is_an_error_not_a_silent_drop(self):
+        # Every zone box is read through the System check, so a UiMap export
+        # without the column would quietly yield no zones at all rather than
+        # failing. load() declares it required for exactly that reason.
+        directory = self.build_inputs([
+            self.node(1, "Havenhold, Alpha Vale", 50, 50),
+            self.node(2, "Farpost, Beta Reach", 250, 250),
+            self.node(3, "Waypost, Beta Reach", 260, 260),
+        ])
+        path = os.path.join(directory, "UiMap.csv")
+        rows = list(csv.DictReader(open(path, encoding="utf-8")))
+        for row in rows:
+            del row["System"]
+        write_csv(path, ["Name_lang", "ID", "Type"], rows)
+        gen.MIN_ZONES = 0
+        with self.assertRaises(SystemExit):
+            gen.build(directory)
 
     def test_an_internal_flagged_node_is_dropped(self):
         result = self.resolve([


### PR DESCRIPTION
Found while re-deriving the first half of [#28](https://github.com/CybotTM/wow-quickroute/issues/28), which turned out to be about something else. This is the defect that measurement uncovered instead.

## What it was

`UiMap` ships a second set of zone maps under `System = 2` — the same zones under different IDs, on assignment boxes covering the same world coordinates. They compete for every taxi node, and where one won the flight master was filed under an ID no player is ever on.

Seven of the 147 shipped flight points were:

| shipped | should be | zone | known to `ZoneAdjacency.lua`? |
|---|---|---|---|
| 1187 | 630 | Azsuna | shipped ID: no · correct ID: yes |
| 1569 | 1533 | Bastion | no · no |
| 2271 | 2248 | Isle of Dorn | no · yes |
| 2272 | 2214 | The Ringing Deeps | no · yes |
| 2273 | 2215 | Hallowfall | no · yes |
| 2480 | 2413 | Harandar | no · yes |
| 2270 | 2255 | Azj-Kahet | no · yes, and 2255 already had its own entry |

**Five of those IDs are ones the addon's zone tables do not know at all.** Those zones had a flight master in the data and no flight edge in the graph. It also accounts for the observation recorded in [#33](https://github.com/CybotTM/wow-quickroute/issues/33) that The Ringing Deeps has no node for a flight to attach to.

The coordinates move for three of them as well, because the projection now runs against the right zone's box.

## Measured, including the part that is not a win

Against `main`, both factions, every flight point discovered:

- flight edges: **509 → 527**
- zone-to-capital routes changed: **0 of 306**
- routes into the six affected zones changed: **0 of 1824**

So the data was wrong and the routing effect today is nil — the new edges never beat a portal. Stated rather than buried: this is a correctness fix, not a speed one. It is worth shipping because an entry keyed on a map the player is never on cannot become right later, and unlike [#33](https://github.com/CybotTM/wow-quickroute/issues/33) it costs no new data field and no runtime condition.

Entry count drops 147 → 146: the duplicate Azj-Kahet entry goes, and the correct one was already there.

## Verified

| injection | result |
|---|---|
| the `System` filter removed | the generator test names the duplicate; the shipped-data test lists all seven |
| `System` dropped from the required columns | the missing-column test — an export without it would otherwise yield no zones silently |
| regenerate without the filter, then run the Lua suite | both data guards red, all seven and all six named |

`System` is now a required column on `UiMap.csv` for that reason. The committed `FlightPoints.lua` is byte-identical to a fresh run of the committed generator.

13603 Lua assertions, 0 failures, in both file orders; 39 Python tests; luacheck 0 warnings / 0 errors in 72 files.

## Leaves issue 28 open

Its first half is about Rebel Camp, a different defect — and one the issue describes incorrectly. A comment there has the measurement.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
