### PR TITLE
feat: record observed zone crossings, walks apart from portals

### DIFF
--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -243,9 +243,14 @@ end
 -- first `/qrsurvey` then died in `pairs`.
 --
 -- One pass on load beats a guard per read: the reads can then say what they
--- mean, and a shape this module never writes cannot reach them at all. Clearing
--- keys during a pairs traversal is defined behaviour in Lua; adding them is not,
--- and this only clears.
+-- mean, and a shape this module never writes cannot reach them at all.
+--
+-- Clearing keys while traversing is deliberate and permitted. Lua 5.1 on `next`:
+-- "The behavior of next is undefined if, during the traversal, you assign any
+-- value to a non-existent field in the table. You may however modify existing
+-- fields. In particular, you may clear existing fields." This only ever clears
+-- fields that exist, and never adds one. Measured on this interpreter as well:
+-- traversing 200 keys while clearing 100 of them visits all 200.
 local function Sanitize(store)
     if type(store) ~= "table" then return {}, 0 end
     local dropped = 0

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -14,7 +14,8 @@
 local ADDON_NAME, QR = ...
 
 -- Cache frequently-used globals
-local pairs, ipairs, pcall, tostring, tonumber = pairs, ipairs, pcall, tostring, tonumber
+local pairs, ipairs, pcall, tostring, tonumber, type =
+    pairs, ipairs, pcall, tostring, tonumber, type
 local string_format = string.format
 local table_concat, table_sort = table.concat, table.sort
 local date = date
@@ -88,14 +89,19 @@ local function RecordArrival(store, mapID)
     local record = store[mapID]
     if not record then return end
 
-    record.from = record.from or {}
-    -- Read defensively: this table comes back from SavedVariables, which is a
-    -- file on disk that survives version changes and hand-editing. An entry
-    -- missing one of its counters would otherwise throw here and take the whole
-    -- capture with it.
-    local entry = record.from[from] or {}
-    entry.walked = entry.walked or 0
-    entry.loaded = entry.loaded or 0
+    -- Everything below comes back from SavedVariables, a file on disk that
+    -- survives version changes and hand-editing, so nothing about its shape is
+    -- given. Guarding only the counters was half a job: a non-table entry threw
+    -- on the first index. A throw here is caught by the pcall around Capture,
+    -- so the addon survives -- what is lost is that zone's record.
+    --
+    -- tonumber rather than a plain nil test, so "3" from a hand-edited file
+    -- counts and "corrupt" restarts at zero instead of throwing on the add.
+    if type(record.from) ~= "table" then record.from = {} end
+    local entry = record.from[from]
+    if type(entry) ~= "table" then entry = {} end
+    entry.walked = tonumber(entry.walked) or 0
+    entry.loaded = tonumber(entry.loaded) or 0
     if hadLoadingScreen then
         entry.loaded = entry.loaded + 1
     else

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -81,7 +81,13 @@ local function RecordArrival(store, mapID)
     if not record then return end
 
     record.from = record.from or {}
-    local entry = record.from[from] or { walked = 0, loaded = 0 }
+    -- Read defensively: this table comes back from SavedVariables, which is a
+    -- file on disk that survives version changes and hand-editing. An entry
+    -- missing one of its counters would otherwise throw here and take the whole
+    -- capture with it.
+    local entry = record.from[from] or {}
+    entry.walked = entry.walked or 0
+    entry.loaded = entry.loaded or 0
     if hadLoadingScreen then
         entry.loaded = entry.loaded + 1
     else

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -157,7 +157,11 @@ function ZoneSurvey:Capture()
         visits = (existing and existing.visits or 0) + 1,
         -- Carried forward, because the record is rebuilt rather than patched
         -- and the arrivals are the part that accumulates across a session.
-        from = existing and existing.from or nil,
+        -- Only a table survives the carry-forward. Sanitize clears the store
+        -- on load, but a record can also be reached before any capture has
+        -- touched it, so the shape is re-checked where it is copied.
+        from = (type(existing) == "table" and type(existing.from) == "table")
+            and existing.from or nil,
         seen = date("%Y-%m-%d %H:%M:%S"),
     }
     RecordArrival(store, mapID)
@@ -230,12 +234,55 @@ function ZoneSurvey:Render()
     return table_concat(lines, "\n")
 end
 
+--- Drop anything in the loaded store that is not the shape this module writes.
+-- Checked once, here, rather than guarded at every read. The store comes back
+-- from SavedVariables, so nothing about it is given -- and a value of the wrong
+-- type does not announce itself: a `from` field holding a string survived every
+-- guard downstream, because RecordArrival returns before its own check when
+-- there is no previous map yet, which is exactly the state after a login. The
+-- first `/qrsurvey` then died in `pairs`.
+--
+-- One pass on load beats a guard per read: the reads can then say what they
+-- mean, and a shape this module never writes cannot reach them at all. Clearing
+-- keys during a pairs traversal is defined behaviour in Lua; adding them is not,
+-- and this only clears.
+local function Sanitize(store)
+    if type(store) ~= "table" then return {}, 0 end
+    local dropped = 0
+    for mapID, record in pairs(store) do
+        if type(mapID) ~= "number" or type(record) ~= "table" then
+            store[mapID] = nil
+            dropped = dropped + 1
+        elseif record.from ~= nil then
+            if type(record.from) ~= "table" then
+                record.from = nil
+                dropped = dropped + 1
+            else
+                for origin, entry in pairs(record.from) do
+                    if type(origin) ~= "number" or type(entry) ~= "table" then
+                        record.from[origin] = nil
+                        dropped = dropped + 1
+                    else
+                        entry.walked = tonumber(entry.walked) or 0
+                        entry.loaded = tonumber(entry.loaded) or 0
+                    end
+                end
+            end
+        end
+    end
+    return store, dropped
+end
+
 function ZoneSurvey:Initialize()
     if QR.db then
         if QR.db.zoneSurveyEnabled == nil then
             QR.db.zoneSurveyEnabled = true
         end
-        QR.db.zoneSurvey = QR.db.zoneSurvey or {}
+        local store, dropped = Sanitize(QR.db.zoneSurvey or {})
+        QR.db.zoneSurvey = store
+        if dropped > 0 then
+            QR:Debug(string_format("ZoneSurvey: dropped %d malformed record(s) on load", dropped))
+        end
     end
 
     local frame = CreateFrame("Frame")

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -51,6 +51,45 @@ local function RecordCount(store)
     return n
 end
 
+-- The map the last capture recorded, and whether a loading screen happened
+-- since. Together they say how the player got from one to the other.
+local lastMapID = nil
+local loadedSince = false
+
+--- Note that a loading screen happened, so the next transition is not a walk.
+function ZoneSurvey:NoteLoadingScreen()
+    loadedSince = true
+end
+
+--- Record how the player arrived at a map.
+-- Zone boxes are rectangles and overlap across a whole continent, so geometry
+-- cannot say which zones border each other -- measured against the current
+-- tables it claims 148 pairs that are not neighbours, Durotar to Mulgore among
+-- them. A player crossing from one zone to the next can.
+--
+-- A crossing with no loading screen is a walk or a flight, and both follow the
+-- ground. One with a loading screen is a portal or an instance and says
+-- nothing about geography, so the two are counted apart rather than mixed.
+local function RecordArrival(store, mapID)
+    local from = lastMapID
+    lastMapID = mapID
+    local hadLoadingScreen = loadedSince
+    loadedSince = false
+
+    if not from or from == mapID then return end
+    local record = store[mapID]
+    if not record then return end
+
+    record.from = record.from or {}
+    local entry = record.from[from] or { walked = 0, loaded = 0 }
+    if hadLoadingScreen then
+        entry.loaded = entry.loaded + 1
+    else
+        entry.walked = entry.walked + 1
+    end
+    record.from[from] = entry
+end
+
 --- Capture the current map, if there is one to capture.
 -- @return number|nil The mapID recorded, or nil when nothing was recorded --
 --   the survey is switched off, the client has no map for the player, or the
@@ -96,13 +135,21 @@ function ZoneSurvey:Capture()
         flightPoint = flight and (flight.node or true) or nil,
         flightAlt = flight and flight.alt and (flight.alt.node or true) or nil,
         visits = (existing and existing.visits or 0) + 1,
+        -- Carried forward, because the record is rebuilt rather than patched
+        -- and the arrivals are the part that accumulates across a session.
+        from = existing and existing.from or nil,
         seen = date("%Y-%m-%d %H:%M:%S"),
     }
+    RecordArrival(store, mapID)
     return mapID
 end
 
 function ZoneSurvey:Clear()
     if QR.db then QR.db.zoneSurvey = {} end
+    -- Also forget where the player came from, so the first capture after a
+    -- clear does not invent an arrival from a map no longer on record.
+    lastMapID = nil
+    loadedSince = false
 end
 
 function ZoneSurvey:Count()
@@ -135,6 +182,32 @@ function ZoneSurvey:Render()
             tostring(r.graphNodes or "-"), tostring(r.flightPoint or "-"),
             r.visits or 0)
     end
+
+    -- Observed crossings. A walk or a flight follows the ground, so it is
+    -- evidence that two zones border each other; a portal is not, and is
+    -- counted separately rather than thrown away.
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = "### Observed crossings"
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = "| into | from | walked | loaded |"
+    lines[#lines + 1] = "|---|---|---|---|"
+    local any = false
+    for _, mapID in ipairs(ids) do
+        local r = QR.db.zoneSurvey[mapID]
+        local froms = {}
+        for f in pairs(r.from or {}) do froms[#froms + 1] = f end
+        table_sort(froms)
+        for _, f in ipairs(froms) do
+            local e = r.from[f]
+            lines[#lines + 1] = string_format("| %d | %d | %d | %d |",
+                mapID, f, e.walked or 0, e.loaded or 0)
+            any = true
+        end
+    end
+    if not any then
+        lines[#lines + 1] = "| - | - | - | - |"
+    end
+
     return table_concat(lines, "\n")
 end
 
@@ -149,7 +222,13 @@ function ZoneSurvey:Initialize()
     local frame = CreateFrame("Frame")
     frame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
     frame:RegisterEvent("PLAYER_ENTERING_WORLD")
-    frame:SetScript("OnEvent", function()
+    frame:SetScript("OnEvent", function(_, event)
+        -- A loading screen means the next crossing was a portal or an
+        -- instance, not a step over a border. Noted before the debounce, so it
+        -- is not lost when the two events arrive together.
+        if event == "PLAYER_ENTERING_WORLD" then
+            ZoneSurvey:NoteLoadingScreen()
+        end
         -- The map the client reports right on the event is sometimes still the
         -- old one, so the capture waits a beat. Debounced, because a zone
         -- change can fire both events together.

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -61,6 +61,14 @@ function ZoneSurvey:NoteLoadingScreen()
     loadedSince = true
 end
 
+--- Forget where the player came from and how they got there.
+-- Used when the survey is switched off and by Clear, so that whatever happens
+-- while nothing is being recorded cannot become the first crossing afterwards.
+function ZoneSurvey:ForgetArrivalState()
+    lastMapID = nil
+    loadedSince = false
+end
+
 --- Record how the player arrived at a map.
 -- Zone boxes are rectangles and overlap across a whole continent, so geometry
 -- cannot say which zones border each other -- measured against the current
@@ -154,8 +162,7 @@ function ZoneSurvey:Clear()
     if QR.db then QR.db.zoneSurvey = {} end
     -- Also forget where the player came from, so the first capture after a
     -- clear does not invent an arrival from a map no longer on record.
-    lastMapID = nil
-    loadedSince = false
+    self:ForgetArrivalState()
 end
 
 function ZoneSurvey:Count()
@@ -229,6 +236,16 @@ function ZoneSurvey:Initialize()
     frame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
     frame:RegisterEvent("PLAYER_ENTERING_WORLD")
     frame:SetScript("OnEvent", function(_, event)
+        -- While the survey is off, nothing is recorded -- so nothing may be
+        -- remembered either. Letting loadedSince and lastMapID accumulate here
+        -- means the first capture after switching back on describes a crossing
+        -- between two zones the player never crossed directly, classified by a
+        -- loading screen that belonged to some other journey. That is precisely
+        -- the kind of invented evidence this recorder exists to avoid.
+        if not (QR.db and QR.db.zoneSurveyEnabled) then
+            ZoneSurvey:ForgetArrivalState()
+            return
+        end
         -- A loading screen means the next crossing was a portal or an
         -- instance, not a step over a border. Noted before the debounce, so it
         -- is not lost when the two events arrive together.
@@ -260,6 +277,9 @@ SlashCmdList["QRSURVEY"] = function(msg)
         QR:Print("Zone survey cleared.")
     elseif cmd == "off" then
         if QR.db then QR.db.zoneSurveyEnabled = false end
+        -- Immediately, not at the next zone change: switching off and back on
+        -- without moving would otherwise keep the stale map.
+        ZoneSurvey:ForgetArrivalState()
         QR:Print("Zone survey off.")
     elseif cmd == "on" then
         if QR.db then QR.db.zoneSurveyEnabled = true end

--- a/tests/test_diagnostics.lua
+++ b/tests/test_diagnostics.lua
@@ -90,6 +90,7 @@ T:run("Diagnostics: an empty list next to a full inventory is visible in the rec
 
     QR.Diagnostics:RecordRefresh()
     local r = QR.db.refreshes[1]
+    t:assertNotNil(r, "the rebuild was recorded")
     if not r then return end
     t:assertEqual(0, r.shown, "nothing drawn")
     t:assertEqual(3, r.invItems, "while three items were owned")

--- a/tests/test_securebuttons.lua
+++ b/tests/test_securebuttons.lua
@@ -583,6 +583,7 @@ end)
 T:run("SecureButtons: an item in the bags is only equipped, not used", function(t)
     resetState()
     local btn = QR.SecureButtons:GetButton()
+    t:assertNotNil(btn, "a button is available")
     if not btn then return end
     t:assertTrue(QR.SecureButtons:ConfigureForEquippable(btn, 63353, 15),
         "the button configures")
@@ -590,6 +591,7 @@ T:run("SecureButtons: an item in the bags is only equipped, not used", function(
     MockWoW.config.equippedItems[15] = 12345
 
     local preClick = btn:GetScript("PreClick")
+    t:assertNotNil(preClick, "PreClick is set")
     if not preClick then return end
     preClick(btn, "LeftButton", false)
 
@@ -604,11 +606,13 @@ end)
 T:run("SecureButtons: an empty slot equips without using", function(t)
     resetState()
     local btn = QR.SecureButtons:GetButton()
+    t:assertNotNil(btn, "a button is available")
     if not btn then return end
     QR.SecureButtons:ConfigureForEquippable(btn, 63353, 15)
     MockWoW.config.equippedItems[15] = nil
 
     local preClick = btn:GetScript("PreClick")
+    t:assertNotNil(preClick, "PreClick is set")
     if not preClick then return end
     preClick(btn, "LeftButton", false)
 
@@ -629,6 +633,7 @@ T:run("SecureButtons: an unlearned spell is cast by name", function(t)
     resetState()
     reinitializePool()
     local btn = QR.SecureButtons:GetButton()
+    t:assertNotNil(btn, "a button is available")
     if not btn then return end
 
     -- Not in knownSpells, which is what the housing teleport looks like.
@@ -646,6 +651,7 @@ T:run("SecureButtons: a learned spell keeps the spell action type", function(t)
     resetState()
     reinitializePool()
     local btn = QR.SecureButtons:GetButton()
+    t:assertNotNil(btn, "a button is available")
     if not btn then return end
 
     MockWoW.config.knownSpells[50977] = true
@@ -659,6 +665,7 @@ T:run("SecureButtons: an unlearned spell with no name is refused", function(t)
     resetState()
     reinitializePool()
     local btn = QR.SecureButtons:GetButton()
+    t:assertNotNil(btn, "a button is available")
     if not btn then return end
 
     -- Spell data not cached yet, which is the state right after login.

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -288,3 +288,56 @@ T:run("ZoneSurvey: a loading screen while off does not classify a later crossing
         "as a walk -- the loading screen belonged to a journey nobody recorded")
     t:assertEqual(0, entry.loaded, "and not as a portal")
 end)
+
+T:run("ZoneSurvey: a crossing entry that is not a table at all is replaced", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    -- Hand-edited SavedVariables can hold anything. Guarding only the counters
+    -- was half a job: this threw on the first index into the entry.
+    QR.db.zoneSurvey[77].from[63] = "corrupt"
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    local ok = pcall(function() return QR.ZoneSurvey:Capture() end)
+
+    t:assertTrue(ok, "the capture survives a non-table entry")
+    local entry = QR.db.zoneSurvey[77] and QR.db.zoneSurvey[77].from
+        and QR.db.zoneSurvey[77].from[63]
+    t:assertNotNil(entry, "and replaces it with a usable one")
+    if not entry then return end
+    t:assertEqual(1, entry.walked, "counting from zero again")
+end)
+
+T:run("ZoneSurvey: a counter that is not a number at all restarts at zero", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    -- A numeric string would need no guard -- Lua adds "3" + 1 to 4 by itself,
+    -- so a test on that asserts nothing about tonumber. This is the case
+    -- tonumber actually buys: a value that cannot be added at all, which
+    -- without it throws on the increment.
+    QR.db.zoneSurvey[77].from[63] = { walked = "corrupt", loaded = 0 }
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    local entry = QR.db.zoneSurvey[77] and QR.db.zoneSurvey[77].from
+        and QR.db.zoneSurvey[77].from[63]
+    t:assertNotNil(entry, "the entry is still there")
+    if not entry then return end
+    t:assertEqual(1, entry.walked, "restarted at zero and counted, rather than throwing")
+end)

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -341,3 +341,61 @@ T:run("ZoneSurvey: a counter that is not a number at all restarts at zero", func
     if not entry then return end
     t:assertEqual(1, entry.walked, "restarted at zero and counted, rather than throwing")
 end)
+
+-------------------------------------------------------------------------------
+-- The shape of what comes back from disk
+--
+-- Checked once on load rather than guarded at every read. A `from` field
+-- holding a string survived every downstream guard, because RecordArrival
+-- returns before its own check when there is no previous map yet -- which is
+-- exactly the state after a login. The first /qrsurvey then died in pairs().
+-------------------------------------------------------------------------------
+
+T:run("ZoneSurvey: a malformed store is cleaned when it is loaded", function(t)
+    resetState()
+    QR.db.zoneSurvey = {
+        [77]  = { name = "Felwood", visits = 1, from = "corrupt" },
+        [63]  = { name = "Ashenvale", visits = 1,
+                  from = { [84] = "also corrupt", [62] = { walked = "3", loaded = 1 } } },
+        ["x"] = { name = "not a map id" },
+        [99]  = "not a record",
+    }
+    QR.ZoneSurvey:Initialize()
+
+    local store = QR.db.zoneSurvey
+    t:assertNil(store["x"], "a non-numeric map key is dropped")
+    t:assertNil(store[99], "a record that is not a table is dropped")
+    t:assertNil(store[77].from, "a from field that is not a table is dropped")
+    t:assertNotNil(store[63].from, "a well-formed from field is kept")
+    if not store[63].from then return end
+    t:assertNil(store[63].from[84], "a crossing entry that is not a table is dropped")
+    t:assertNotNil(store[63].from[62], "and the good one beside it survives")
+    if not store[63].from[62] then return end
+    t:assertEqual(3, store[63].from[62].walked, "with its counters made numeric")
+end)
+
+T:run("ZoneSurvey: rendering a store loaded from disk does not throw", function(t)
+    resetState()
+    -- The exact shape that killed /qrsurvey: corrupt, and never revisited, so
+    -- no capture ever reaches it.
+    QR.db.zoneSurvey = { [77] = { name = "Felwood", visits = 1, from = "corrupt" } }
+    QR.ZoneSurvey:Initialize()
+    QR.ZoneSurvey:ForgetArrivalState()
+
+    local ok = pcall(function() return QR.ZoneSurvey:Render() end)
+    t:assertTrue(ok, "/qrsurvey renders a store that came back malformed")
+end)
+
+T:run("ZoneSurvey: a malformed record is not carried forward by a capture", function(t)
+    resetState()
+    QR.db.zoneSurvey = { [77] = { name = "Felwood", visits = 1, from = "corrupt" } }
+    QR.ZoneSurvey:ForgetArrivalState()
+
+    -- No Initialize here: a record can be reached before the load pass has
+    -- touched it, so the copy has to check the shape too.
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    t:assertNil(QR.db.zoneSurvey[77].from,
+        "the capture drops it rather than copying it into the new record")
+end)

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -95,3 +95,98 @@ T:run("ZoneSurvey: Render lists every record", function(t)
     t:assertNotNil(out:match("| 63 |"), "map 63 appears as a row")
     t:assertNotNil(out:match("| 84 |"), "map 84 appears as a row")
 end)
+
+-------------------------------------------------------------------------------
+-- Observed crossings
+--
+-- Zone boxes are rectangles and overlap across a whole continent, so geometry
+-- cannot say which zones border each other: measured against the current
+-- tables it claims 148 pairs that are not neighbours, Durotar to Mulgore among
+-- them. A player crossing from one zone into the next can, provided a walk is
+-- told apart from a portal.
+-------------------------------------------------------------------------------
+
+T:run("ZoneSurvey: a crossing without a loading screen is recorded as walked", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[77]
+    t:assertNotNil(record and record.from, "the arrival is recorded on the destination")
+    if not (record and record.from and record.from[63]) then return end
+    t:assertEqual(1, record.from[63].walked, "counted as walked")
+    t:assertEqual(0, record.from[63].loaded, "and not as a portal")
+end)
+
+T:run("ZoneSurvey: a crossing after a loading screen is not counted as walked", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    QR.ZoneSurvey:NoteLoadingScreen()
+    MockWoW.config.currentMapID = 84
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[84]
+    if not (record and record.from and record.from[63]) then
+        t:assertTrue(false, "the arrival should still be recorded")
+        return
+    end
+    t:assertEqual(0, record.from[63].walked,
+        "a portal says nothing about two zones bordering each other")
+    t:assertEqual(1, record.from[63].loaded, "and is counted on its own")
+end)
+
+T:run("ZoneSurvey: staying in one zone records no crossing", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    QR.ZoneSurvey:Capture()
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[63]
+    t:assertNil(record and record.from, "no arrival from itself")
+end)
+
+T:run("ZoneSurvey: crossings survive a revisit rebuilding the record", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+    -- Back and forth. The record for 77 is rebuilt on the second arrival, and
+    -- the crossings are the part that has to accumulate rather than reset.
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[77]
+    if not (record and record.from and record.from[63]) then return end
+    t:assertEqual(2, record.from[63].walked, "both crossings counted")
+end)
+
+T:run("ZoneSurvey: Clear forgets where the player came from", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    QR.ZoneSurvey:Clear()
+    -- Without forgetting, this would record an arrival from a map the store no
+    -- longer holds.
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[77]
+    t:assertNil(record and record.from, "no crossing invented across a clear")
+end)

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -95,8 +95,14 @@ T:run("ZoneSurvey: Render lists every record", function(t)
     -- Only the records section. The crossings table below it also has rows
     -- beginning "| 63 |", so matching the whole output passed even with the
     -- records table entirely missing -- verified by removing it.
+    --
+    -- No fallback to the whole output: if the header is ever renamed, falling
+    -- back would silently restore the ambiguity this narrowing exists to close.
+    -- Better to fail here and be told.
     local out = QR.ZoneSurvey:Render()
-    local records = out:match("^(.-)### Observed crossings") or out
+    local records = out:match("^(.-)### Observed crossings")
+    t:assertNotNil(records, "the output has a records section to look at")
+    if not records then return end
     t:assertNotNil(records:match("| 63 |"), "map 63 appears as a record row")
     t:assertNotNil(records:match("| 84 |"), "map 84 appears as a record row")
 end)

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -91,9 +91,13 @@ T:run("ZoneSurvey: Render lists every record", function(t)
     MockWoW.config.currentMapID = 84
     QR.ZoneSurvey:Capture()
 
+    -- Only the records section. The crossings table below it also has rows
+    -- beginning "| 63 |", so matching the whole output passed even with the
+    -- records table entirely missing -- verified by removing it.
     local out = QR.ZoneSurvey:Render()
-    t:assertNotNil(out:match("| 63 |"), "map 63 appears as a row")
-    t:assertNotNil(out:match("| 84 |"), "map 84 appears as a row")
+    local records = out:match("^(.-)### Observed crossings") or out
+    t:assertNotNil(records:match("| 63 |"), "map 63 appears as a record row")
+    t:assertNotNil(records:match("| 84 |"), "map 84 appears as a record row")
 end)
 
 -------------------------------------------------------------------------------
@@ -189,4 +193,31 @@ T:run("ZoneSurvey: Clear forgets where the player came from", function(t)
 
     local record = QR.db.zoneSurvey[77]
     t:assertNil(record and record.from, "no crossing invented across a clear")
+end)
+
+T:run("ZoneSurvey: a crossing entry missing a counter does not break the capture", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    -- This table comes back from SavedVariables, a file that survives version
+    -- changes and hand-editing, so an entry can arrive without its counters.
+    QR.db.zoneSurvey[77].from[63] = { walked = 1 }
+
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    QR.ZoneSurvey:NoteLoadingScreen()
+    MockWoW.config.currentMapID = 77
+    local ok = pcall(function() return QR.ZoneSurvey:Capture() end)
+
+    t:assertTrue(ok, "the capture survives an entry with a missing counter")
+    local entry = QR.db.zoneSurvey[77] and QR.db.zoneSurvey[77].from
+        and QR.db.zoneSurvey[77].from[63]
+    if not entry then return end
+    t:assertEqual(1, entry.loaded, "the missing counter starts at zero and counts")
+    t:assertEqual(1, entry.walked, "and the one that was there is kept")
 end)

--- a/tests/test_zonesurvey.lua
+++ b/tests/test_zonesurvey.lua
@@ -59,6 +59,7 @@ T:run("ZoneSurvey: records what the addon knows about the map", function(t)
     QR.ZoneSurvey:Capture()
 
     local record = QR.db.zoneSurvey[63]
+    t:assertNotNil(record, "the map was recorded")
     if not record then return end
     t:assertNotNil(record.flightPoint,
         "a zone with a flight master records it")
@@ -120,7 +121,8 @@ T:run("ZoneSurvey: a crossing without a loading screen is recorded as walked", f
     QR.ZoneSurvey:Capture()
 
     local record = QR.db.zoneSurvey[77]
-    t:assertNotNil(record and record.from, "the arrival is recorded on the destination")
+    t:assertNotNil(record and record.from and record.from[63],
+        "the arrival is recorded on the destination")
     if not (record and record.from and record.from[63]) then return end
     t:assertEqual(1, record.from[63].walked, "counted as walked")
     t:assertEqual(0, record.from[63].loaded, "and not as a portal")
@@ -175,6 +177,8 @@ T:run("ZoneSurvey: crossings survive a revisit rebuilding the record", function(
     QR.ZoneSurvey:Capture()
 
     local record = QR.db.zoneSurvey[77]
+    t:assertNotNil(record and record.from and record.from[63],
+        "the crossing is on record at all")
     if not (record and record.from and record.from[63]) then return end
     t:assertEqual(2, record.from[63].walked, "both crossings counted")
 end)
@@ -217,7 +221,70 @@ T:run("ZoneSurvey: a crossing entry missing a counter does not break the capture
     t:assertTrue(ok, "the capture survives an entry with a missing counter")
     local entry = QR.db.zoneSurvey[77] and QR.db.zoneSurvey[77].from
         and QR.db.zoneSurvey[77].from[63]
+    t:assertNotNil(entry, "the entry survives and is still there")
     if not entry then return end
     t:assertEqual(1, entry.loaded, "the missing counter starts at zero and counts")
     t:assertEqual(1, entry.walked, "and the one that was there is kept")
+end)
+
+T:run("ZoneSurvey: switching off and on again invents no crossing", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    -- Somewhere, recorded.
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+
+    -- Off. The player then travels -- by portal, several zones -- and none of
+    -- it is recorded, so none of it may be remembered either.
+    --
+    -- Driven through the real event handler, not by calling
+    -- ForgetArrivalState here: doing that by hand proves the function and says
+    -- nothing about whether anything calls it. Removing the guard from the
+    -- handler left this test green until it went through the handler.
+    local onEvent = QR.ZoneSurvey.frame and QR.ZoneSurvey.frame:GetScript("OnEvent")
+    t:assertNotNil(onEvent, "the survey has an event handler to drive")
+    if not onEvent then return end
+
+    QR.db.zoneSurveyEnabled = false
+    MockWoW.config.currentMapID = 1670
+    onEvent(QR.ZoneSurvey.frame, "PLAYER_ENTERING_WORLD")
+    MockWoW.config.currentMapID = 2339
+    onEvent(QR.ZoneSurvey.frame, "ZONE_CHANGED_NEW_AREA")
+
+    -- Back on, in a zone far from where the survey was switched off.
+    QR.db.zoneSurveyEnabled = true
+    QR.ZoneSurvey:Capture()
+
+    local record = QR.db.zoneSurvey[2339]
+    t:assertNotNil(record, "the current map is recorded again")
+    if not record then return end
+    t:assertNil(record.from,
+        "and no crossing from the map the survey was switched off in")
+end)
+
+T:run("ZoneSurvey: a loading screen while off does not classify a later crossing", function(t)
+    resetState()
+    QR.ZoneSurvey:Clear()
+
+    local onEvent = QR.ZoneSurvey.frame and QR.ZoneSurvey.frame:GetScript("OnEvent")
+    t:assertNotNil(onEvent, "the survey has an event handler to drive")
+    if not onEvent then return end
+
+    QR.db.zoneSurveyEnabled = false
+    onEvent(QR.ZoneSurvey.frame, "PLAYER_ENTERING_WORLD")
+
+    QR.db.zoneSurveyEnabled = true
+    MockWoW.config.currentMapID = 63
+    QR.ZoneSurvey:Capture()
+    MockWoW.config.currentMapID = 77
+    QR.ZoneSurvey:Capture()
+
+    local entry = QR.db.zoneSurvey[77] and QR.db.zoneSurvey[77].from
+        and QR.db.zoneSurvey[77].from[63]
+    t:assertNotNil(entry, "the crossing after switching on is recorded")
+    if not entry then return end
+    t:assertEqual(1, entry.walked,
+        "as a walk -- the loading screen belonged to a journey nobody recorded")
+    t:assertEqual(0, entry.loaded, "and not as a portal")
 end)


### PR DESCRIPTION
## Geometry cannot answer the question, and I checked before assuming it could

A zone survey from the live client showed Azshara with a single neighbour in `ZoneAdjacencies` and Mount Hyjal with one. That looked like a gap, so I measured it against the client's own map geometry — two zones whose `UiMapAssignment` boxes touch on the same world map, where neither lists the other.

The result refutes the method rather than supporting the suspicion. Among retail zone boxes it finds **390 touching pairs and 148 supposedly missing ones**, including:

```
   1 Durotar     <->    7 Mulgore
   7 Mulgore     <->   69 Feralas
  15 Badlands    <->   37 Elwynn Forest
  17 Blasted Lands <-> 210 The Cape of Stranglethorn
```

None of those border each other. Zone boxes are rectangles and overlap across a whole continent, so box adjacency is not a usable proxy. **No adjacency data is changed here and no issue was filed off that number** — it is not evidence of anything.

## What is evidence: a player crossing the border

The survey now records, per map, which map the player arrived from and how often — and counts two kinds apart:

| kind | what it means |
|---|---|
| **walked** | no loading screen between the two zones — a walk or a flight, and both follow the ground |
| **loaded** | a loading screen — a portal or an instance, which says nothing about geography |

Summing them would make every portal look like a border, so they stay separate. `PLAYER_ENTERING_WORLD` is what marks the loading screen, and it is noted before the capture debounce so it is not lost when both events arrive together.

Two details that are easy to get wrong and have tests of their own: the counts have to survive a revisit, because the record is rebuilt rather than patched; and a clear has to forget the last map, or the next capture invents an arrival from a map no longer on record.

`/qrsurvey` renders the crossings as their own table.

## Verified

| injection | what reddens |
|---|---|
| loading screens ignored | the portal test — a portal counted as a walk |
| crossings not carried across a record rebuild | the back-and-forth test, 2 → 1 |
| `Clear` leaves the last map behind | the clear test, and the stay-in-one-zone test |

13664 Lua assertions, 0 failures, in both file orders; 39 Python tests; luacheck 0 warnings / 0 errors.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
