### PR TITLE
test: cover the capital-city faction filter

### DIFF
--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2756,16 +2756,19 @@ end)
 -- something a test should settle by being written first.
 -------------------------------------------------------------------------------
 
+-- @return table|nil The city nodes, or nil when the graph could not be built --
+--   BuildGraph really does return nil on failure, and reading through that
+--   would surface as an ERROR rather than a failed assertion, which says much
+--   less about what went wrong.
 local function capitalNodes(QR, MockWoW, faction)
-    MockWoW:Reset()
+    resetState()
     MockWoW.config.playerFaction = faction
     MockWoW:FireEvent("ZONE_CHANGED_NEW_AREA")
-    QR.PathCalculator.graph = nil
-    QR.PathCalculator.graphDirty = true
     if QR.PlayerInfo and QR.PlayerInfo.InvalidateCache then
         QR.PlayerInfo:InvalidateCache()
     end
     local graph = QR.PathCalculator:BuildGraph()
+    if not graph then return nil end
     -- Only nodes AddZoneNodes made. Shattrath and both Dalarans are portal hubs
     -- as well, so testing for their mere presence passes whatever this filter
     -- does -- which it did, until dropping the "both" case reddened nothing.
@@ -2780,6 +2783,8 @@ end
 
 T:run("AddZoneNodes: an Alliance character gets no Horde capital", function(t)
     local nodes = capitalNodes(QR, MockWoW, "Alliance")
+    t:assertNotNil(nodes, "the graph was built")
+    if not nodes then return end
 
     t:assertTrue(nodes["Stormwind City"], "their own capital is there")
     t:assertTrue(nodes["Ironforge"], "and the rest of their side")
@@ -2789,6 +2794,8 @@ end)
 
 T:run("AddZoneNodes: a Horde character gets no Alliance capital", function(t)
     local nodes = capitalNodes(QR, MockWoW, "Horde")
+    t:assertNotNil(nodes, "the graph was built")
+    if not nodes then return end
 
     t:assertTrue(nodes["Orgrimmar"], "their own capital is there")
     t:assertTrue(nodes["Thunder Bluff"], "and the rest of their side")
@@ -2799,9 +2806,16 @@ end)
 T:run("AddZoneNodes: a neutral city is there for both sides", function(t)
     local alliance = capitalNodes(QR, MockWoW, "Alliance")
     local horde = capitalNodes(QR, MockWoW, "Horde")
+    t:assertNotNil(alliance and horde, "both graphs were built")
+    if not (alliance and horde) then return end
 
     t:assertTrue(alliance["Shattrath City"], "Shattrath for the Alliance")
     t:assertTrue(horde["Shattrath City"], "and for the Horde")
     t:assertTrue(alliance["Dalaran (Northrend)"], "Dalaran for the Alliance")
     t:assertTrue(horde["Dalaran (Northrend)"], "and for the Horde")
+
+    -- Each test here resets on the way in, so each cleans up after the one
+    -- before it -- which leaves the last one's state for the next file. This
+    -- helper leaves the faction on Horde and a graph built for it.
+    resetState()
 end)

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2740,3 +2740,68 @@ T:run("An answering client with nothing discovered is not the same as no client"
         "an absent API returns nil")
     _G.C_TaxiMap = saved
 end)
+
+-------------------------------------------------------------------------------
+-- AddZoneNodes: the faction filter
+--
+-- Uncovered until now: replacing the condition with `true` left all 13702
+-- assertions green in both file orders, so an Alliance character could have
+-- been given Orgrimmar and Thunder Bluff as graph nodes and nothing would have
+-- noticed. See issue #28.
+--
+-- These pin what the filter does for the two factions. They deliberately say
+-- nothing about a character who is neither -- a neutral pandaren before
+-- choosing a side -- because AddZoneNodes and FlightPointFor disagree about
+-- that case and which of them is right is an open question on #28, not
+-- something a test should settle by being written first.
+-------------------------------------------------------------------------------
+
+local function capitalNodes(QR, MockWoW, faction)
+    MockWoW:Reset()
+    MockWoW.config.playerFaction = faction
+    MockWoW:FireEvent("ZONE_CHANGED_NEW_AREA")
+    QR.PathCalculator.graph = nil
+    QR.PathCalculator.graphDirty = true
+    if QR.PlayerInfo and QR.PlayerInfo.InvalidateCache then
+        QR.PlayerInfo:InvalidateCache()
+    end
+    local graph = QR.PathCalculator:BuildGraph()
+    -- Only nodes AddZoneNodes made. Shattrath and both Dalarans are portal hubs
+    -- as well, so testing for their mere presence passes whatever this filter
+    -- does -- which it did, until dropping the "both" case reddened nothing.
+    local present = {}
+    for name, data in pairs(graph.nodes or {}) do
+        if type(data) == "table" and data.nodeType == "city" then
+            present[name] = true
+        end
+    end
+    return present
+end
+
+T:run("AddZoneNodes: an Alliance character gets no Horde capital", function(t)
+    local nodes = capitalNodes(QR, MockWoW, "Alliance")
+
+    t:assertTrue(nodes["Stormwind City"], "their own capital is there")
+    t:assertTrue(nodes["Ironforge"], "and the rest of their side")
+    t:assertFalse(nodes["Orgrimmar"] or false, "Orgrimmar is not")
+    t:assertFalse(nodes["Thunder Bluff"] or false, "nor Thunder Bluff")
+end)
+
+T:run("AddZoneNodes: a Horde character gets no Alliance capital", function(t)
+    local nodes = capitalNodes(QR, MockWoW, "Horde")
+
+    t:assertTrue(nodes["Orgrimmar"], "their own capital is there")
+    t:assertTrue(nodes["Thunder Bluff"], "and the rest of their side")
+    t:assertFalse(nodes["Stormwind City"] or false, "Stormwind is not")
+    t:assertFalse(nodes["Ironforge"] or false, "nor Ironforge")
+end)
+
+T:run("AddZoneNodes: a neutral city is there for both sides", function(t)
+    local alliance = capitalNodes(QR, MockWoW, "Alliance")
+    local horde = capitalNodes(QR, MockWoW, "Horde")
+
+    t:assertTrue(alliance["Shattrath City"], "Shattrath for the Alliance")
+    t:assertTrue(horde["Shattrath City"], "and for the Horde")
+    t:assertTrue(alliance["Dalaran (Northrend)"], "Dalaran for the Alliance")
+    t:assertTrue(horde["Dalaran (Northrend)"], "and for the Horde")
+end)

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2761,12 +2761,12 @@ end)
 --   would surface as an ERROR rather than a failed assertion, which says much
 --   less about what went wrong.
 local function capitalNodes(QR, MockWoW, faction)
+    -- resetState already fires ZONE_CHANGED_NEW_AREA and invalidates the
+    -- PlayerInfo cache. Doing either again here changes nothing: measured by
+    -- removing each in turn, with the suite green both times -- and the Horde
+    -- test would fail if the faction were being read stale, so it is not.
     resetState()
     MockWoW.config.playerFaction = faction
-    MockWoW:FireEvent("ZONE_CHANGED_NEW_AREA")
-    if QR.PlayerInfo and QR.PlayerInfo.InvalidateCache then
-        QR.PlayerInfo:InvalidateCache()
-    end
     local graph = QR.PathCalculator:BuildGraph()
     if not graph then return nil end
     -- Only nodes AddZoneNodes made. Shattrath and both Dalarans are portal hubs


### PR DESCRIPTION
Takes on the half of [#28](https://github.com/CybotTM/wow-quickroute/issues/28) that needs no decision. It leaves the issue open — the other half does need one.

## The filter was uncovered, and the issue was right about that

`AddZoneNodes` keeps a capital when `nodeData.faction == "both" or nodeData.faction == playerFaction`. Replacing that whole condition with `true` leaves **all 13702 assertions green, in both file orders**. An Alliance character could have been handed Orgrimmar and Thunder Bluff as graph nodes and nothing would have said so.

Three tests pin what it does for the two factions.

## What they deliberately do not say

Nothing about a character who is neither — a neutral pandaren before choosing a side. `AddZoneNodes` gives them no capital at all; `FlightPointFor` does the opposite and gives them every zone's primary flight point. Which is right is the open half of [#28](https://github.com/CybotTM/wow-quickroute/issues/28), and a test written now would settle it by accident rather than by decision. The comment in the test file says so, so the next reader does not take the silence for an oversight.

## The neutral-city test needed a second pass

Its first version asserted that Shattrath and both Dalarans were in the graph. They are — either way. Both are portal hubs, so `AddPortalConnections` puts them there regardless of what this filter does, and dropping the `"both"` case from the condition reddened **nothing**.

It now looks only at nodes `AddZoneNodes` itself made, by their `nodeType`, which is the one thing that separates them from the portal-hub node of the same name.

## Verified

| injection | what reddens |
|---|---|
| `factionMatch = true` | both faction tests, four assertions — the original gap |
| `"both"` case dropped | the neutral test, four assertions — nothing at all before the second pass |

13712 Lua assertions, 0 failures, in both file orders; 39 Python tests; luacheck 0 warnings / 0 errors in 76 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
