### PR TITLE
feat: draw the grouped teleport view as cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - The settings page opens with the header from the design ("C2"): the logo, the addon's name, a subtitle, a line with version and author and the site below it, drawn over a travel network with one route in gold; below it a status bar that says whether TomTom was found (and which version), how many teleports the character has, and a button that opens the route window. The settings themselves are unchanged, and Blizzard's own Defaults button stays where it is.
 
+### Changed
+- The teleport cards are the picture cards of the design ("K2"): a 68px banner carrying the group's icon, scaled to the card's width and cut to the banner rather than squashed, with the destination and its continent at the banner's foot; below it the teleport icons and a round status dot. The window opens at the 820px the cards were designed for, three columns of them; at the former 500px they fell into a single column.
+
 ### Fixed
 - The Kirin Tor Beacon, the Sunreaver Beacon and the Mobile Telemancy Beacon no longer count as ready everywhere. The game accepts the first two only on Isle of Thunder and in the Throne of Thunder, the third only in Suramar; away from there they read NOT HERE in the teleport inventory, the "usable" filter hides them, and the quick-teleport list and the map sidebar leave them out. The data carries the maps as `usableOnMaps`, next to the free-text `restriction` that was already there.
 - The map sidebar's rows show their names and destinations again, and so do the list rows of the teleport inventory. Each text was set and then cleared by a `SetTextToFit()` call without a text, which the client reads as an empty string. The test double had made that call a no-op, which is why no test saw it; it now behaves like the client.

--- a/QuickRoute/Modules/MainFrame.lua
+++ b/QuickRoute/Modules/MainFrame.lua
@@ -30,7 +30,9 @@ local MainFrame = QR.MainFrame
 local L
 
 -- Constants
-local FRAME_WIDTH = 500
+-- 820 is the width the teleport cards were designed at: three columns of
+-- 254px cards. At the former 500 the same cards fell into one column.
+local FRAME_WIDTH = 820
 local FRAME_HEIGHT = 550
 local HEADER_HEIGHT = 52
 local TAB_HEIGHT = 28

--- a/QuickRoute/Modules/TeleportPanel.lua
+++ b/QuickRoute/Modules/TeleportPanel.lua
@@ -7,6 +7,7 @@ local pairs, ipairs, type, tostring = pairs, ipairs, type, tostring
 local math_max = math.max
 local string_format = string.format
 local table_insert, table_sort, table_concat = table.insert, table.sort, table.concat
+local math_floor = math.floor
 local CreateFrame = CreateFrame
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
@@ -22,6 +23,8 @@ QR.TeleportPanel = {
     headerPool = {},  -- Pool of reusable header frames
     rowPool = {},  -- Pool of reusable row frames
     iconPool = {},   -- Pool of reusable icon frames for grid mode
+    cardPool = {},   -- Pool of reusable group cards
+    cards = {},      -- Cards currently on screen
     iconFrames = {}, -- Active icon frames (parallel to teleportRows for grid mode)
     currentFilter = "All",
     sortedTeleports = {},
@@ -57,6 +60,23 @@ local ICON_SIZE = 32
 local PADDING = 10
 
 -- Grid icon constants (grouped mode)
+-- Cards, for the grouped view.
+--
+-- The column count follows the window rather than being fixed, using the same
+-- arithmetic the icon grid already used for iconsPerRow. With a 254 minimum --
+-- below that an icon, a name and a status stop fitting side by side -- the
+-- thresholds fall out as: one column up to 537, two to 803, three above. The
+-- design asked for "about 540" and "about 760"; the second is 804 rather than
+-- 760 because three 254-wide cards plus their gaps and padding need it, and a
+-- threshold that follows from the card is worth more than one that matches a
+-- round number.
+local CARD_MIN_WIDTH = 254
+local CARD_GAP = 12
+local CARD_PADDING = 8
+local CARD_ICON_SIZE = 36
+local CARD_HEIGHT = 94
+local CARD_DOT_SIZE = 8
+
 local GRID_ICON_SIZE = 36
 local GRID_ICON_GAP = 4
 local GRID_ROW_PADDING = 6
@@ -1469,41 +1489,198 @@ function TeleportPanel:ConfigureGridIcon(iconFrame, entry)
     end)
 end
 
---- Create a group's icon row (grid of icons for grouped mode)
--- @param group table The group data with teleports array
--- @param yOffset number Vertical offset for the icon row
--- @return number The new yOffset after the icon row
-function TeleportPanel:CreateGroupIconRow(group, yOffset)
-    local scrollChild = self.frame.scrollChild
-    local panelWidth = self.frame:GetWidth()
-    local availWidth = panelWidth - 50
-    local iconsPerRow = math.floor((availWidth + GRID_ICON_GAP) / (GRID_ICON_SIZE + GRID_ICON_GAP))
-    if iconsPerRow < 1 then iconsPerRow = 1 end
+-------------------------------------------------------------------------------
+-- Group cards
+--
+-- The grouped view draws one card per destination instead of a full-width
+-- header followed by a grid. Name and continent sit one above the other rather
+-- than side by side, because at a card's width they collide; the status is a
+-- dot rather than a dot and a word, for the same reason.
+-------------------------------------------------------------------------------
 
-    local rowStartY = yOffset + GRID_ROW_PADDING
-    local currentRow = 0
+--- How many cards fit across the panel.
+-- @param panelWidth number The panel's current width
+-- @return number At least one
+function TeleportPanel:CardsPerRow(panelWidth)
+    local avail = (panelWidth or 0) - CARD_PADDING * 2
+    local perRow = math_floor((avail + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP))
+    if perRow < 1 then perRow = 1 end
+    return perRow
+end
 
-    for i, entry in ipairs(group.teleports) do
-        local col = (i - 1) % iconsPerRow
-        if col == 0 and i > 1 then
-            currentRow = currentRow + 1
-        end
+--- How wide each card is once they share the row.
+-- Cards stretch to fill rather than leaving a ragged right edge, so the width
+-- is a result of the column count, not the other way round.
+-- @param panelWidth number The panel's current width
+-- @return number, number The card width and the number per row
+function TeleportPanel:CardWidth(panelWidth)
+    local perRow = self:CardsPerRow(panelWidth)
+    local avail = (panelWidth or 0) - CARD_PADDING * 2
+    local width = (avail - (perRow - 1) * CARD_GAP) / perRow
+    if width < 1 then width = 1 end
+    return width, perRow
+end
 
+--- How many teleport icons fit along the foot of a card.
+-- The status dot sits at the right-hand end and is not negotiable, so it comes
+-- off the top before the icons are counted.
+-- @param cardWidth number
+-- @return number At least one
+function TeleportPanel:IconsPerCard(cardWidth)
+    local avail = (cardWidth or 0) - CARD_PADDING * 2 - CARD_DOT_SIZE - CARD_GAP
+    local n = math_floor((avail + GRID_ICON_GAP) / (GRID_ICON_SIZE + GRID_ICON_GAP))
+    if n < 1 then n = 1 end
+    return n
+end
+
+--- Take a card frame from the pool, building one if the pool is empty.
+function TeleportPanel:GetCardFrame()
+    local card = table.remove(self.cardPool)
+    if not card then
+        card = CreateFrame("Frame", nil, nil)
+        card:SetHeight(CARD_HEIGHT)
+
+        local bg = card:CreateTexture(nil, "BACKGROUND")
+        bg:SetAllPoints()
+        bg:SetColorTexture(0.12, 0.12, 0.14, 0.85)
+        card.bg = bg
+
+        local icon = card:CreateTexture(nil, "ARTWORK")
+        icon:SetSize(CARD_ICON_SIZE, CARD_ICON_SIZE)
+        icon:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PADDING, -CARD_PADDING)
+        card.icon = icon
+
+        -- Stacked, not side by side: at a card's width they collide.
+        local nameText = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        nameText:SetPoint("TOPLEFT", icon, "TOPRIGHT", 8, -2)
+        nameText:SetPoint("RIGHT", card, "RIGHT", -CARD_PADDING, 0)
+        nameText:SetJustifyH("LEFT")
+        nameText:SetWordWrap(false)
+        card.nameText = nameText
+
+        local contText = card:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        contText:SetPoint("TOPLEFT", nameText, "BOTTOMLEFT", 0, -2)
+        contText:SetPoint("RIGHT", card, "RIGHT", -CARD_PADDING, 0)
+        contText:SetJustifyH("LEFT")
+        contText:SetWordWrap(false)
+        card.contText = contText
+
+        local dot = card:CreateTexture(nil, "OVERLAY")
+        dot:SetSize(CARD_DOT_SIZE, CARD_DOT_SIZE)
+        dot:SetPoint("BOTTOMRIGHT", card, "BOTTOMRIGHT", -CARD_PADDING, CARD_PADDING + 14)
+        card.dot = dot
+
+        card.iconFrames = {}
+    end
+    return card
+end
+
+--- Give a card back, and its icon frames with it.
+function TeleportPanel:ReleaseCardFrame(card)
+    if not card then return end
+    for _, iconFrame in ipairs(card.iconFrames or {}) do
+        self:ReleaseIconFrame(iconFrame)
+    end
+    if card.iconFrames then wipe(card.iconFrames) end
+    card:Hide()
+    card:SetParent(nil)
+    card:ClearAllPoints()
+    table_insert(self.cardPool, card)
+end
+
+--- Return every card on screen to the pool.
+function TeleportPanel:ClearCards()
+    for _, card in ipairs(self.cards or {}) do
+        self:ReleaseCardFrame(card)
+    end
+    self.cards = {}
+end
+
+--- Colour of the status dot for a group, taken from its best entry.
+local function GroupStatusColor(group)
+    local best = group.teleports and group.teleports[1]
+    local status = best and best.status
+    if status == STATUS.READY then return 0.2, 0.9, 0.3 end
+    if status == STATUS.ON_CD then return 0.95, 0.75, 0.2 end
+    if status == STATUS.OWNED then return 0.6, 0.8, 1.0 end
+    return 0.5, 0.5, 0.5
+end
+
+--- Fill one card for one group.
+-- @param card Frame
+-- @param group table
+-- @param cardWidth number
+function TeleportPanel:ConfigureCard(card, group, cardWidth)
+    card:SetWidth(cardWidth)
+
+    -- The destination icon. There is no artwork for destinations, so this is
+    -- the icon of the group's first-sorted teleport -- which always resolves,
+    -- and is visibly different between hearthstones, portals and toys.
+    local best = group.teleports and group.teleports[1]
+    card.icon:SetTexture(best and GetIconTexture(best)
+        or "Interface\\Icons\\INV_Misc_QuestionMark")
+
+    card.nameText:SetText(C.GOLD .. tostring(group.name or "?") .. C.R)
+
+    local continentKey = group.mapID and QR.GetContinentForZone
+        and QR.GetContinentForZone(group.mapID)
+    local continentName = continentKey and QR.GetLocalizedContinentName
+        and QR.GetLocalizedContinentName(continentKey)
+    card.contText:SetText(C.GRAY .. (continentName or "") .. C.R)
+
+    card.dot:SetColorTexture(GroupStatusColor(group))
+
+    local maxIcons = self:IconsPerCard(cardWidth)
+    local shown = 0
+    for i, entry in ipairs(group.teleports or {}) do
+        if i > maxIcons then break end
         local iconFrame = self:GetIconFrame()
-        iconFrame:SetParent(scrollChild)
-        iconFrame:SetPoint("TOPLEFT", scrollChild, "TOPLEFT",
-            col * (GRID_ICON_SIZE + GRID_ICON_GAP),
-            -(rowStartY + currentRow * (GRID_ICON_SIZE + GRID_ICON_GAP)))
+        iconFrame:SetParent(card)
+        iconFrame:SetPoint("BOTTOMLEFT", card, "BOTTOMLEFT",
+            CARD_PADDING + (i - 1) * (GRID_ICON_SIZE + GRID_ICON_GAP), CARD_PADDING)
         iconFrame:Show()
-
         self:ConfigureGridIcon(iconFrame, entry)
+        table_insert(card.iconFrames, iconFrame)
         table_insert(self.iconFrames, iconFrame)
+        shown = i
     end
 
-    local numRows = math.ceil(#group.teleports / iconsPerRow)
-    local totalHeight = GRID_ROW_PADDING * 2 + numRows * (GRID_ICON_SIZE + GRID_ICON_GAP) - GRID_ICON_GAP
-    return yOffset + totalHeight
+    -- Anything that did not fit is stated rather than silently dropped.
+    local hidden = #(group.teleports or {}) - shown
+    if hidden > 0 then
+        card.contText:SetText(C.GRAY .. (continentName or "")
+            .. (continentName and "  " or "") .. "+" .. hidden .. C.R)
+    end
 end
+
+--- Lay the group cards out in as many columns as the panel allows.
+-- @param groups table Array of groups
+-- @param yOffset number
+-- @return number The offset below the last row of cards
+function TeleportPanel:CreateGroupCards(groups, yOffset)
+    local scrollChild = self.frame.scrollChild
+    local cardWidth, perRow = self:CardWidth(self.frame:GetWidth())
+
+    for i, group in ipairs(groups) do
+        local col = (i - 1) % perRow
+        local row = math_floor((i - 1) / perRow)
+
+        local card = self:GetCardFrame()
+        card:SetParent(scrollChild)
+        card:SetPoint("TOPLEFT", scrollChild, "TOPLEFT",
+            CARD_PADDING + col * (cardWidth + CARD_GAP),
+            -(yOffset + row * (CARD_HEIGHT + CARD_GAP)))
+        card:Show()
+
+        self:ConfigureCard(card, group, cardWidth)
+        table_insert(self.cards, card)
+    end
+
+    local rows = math.ceil(#groups / perRow)
+    if rows < 1 then rows = 0 end
+    return yOffset + rows * (CARD_HEIGHT + CARD_GAP)
+end
+
 
 -------------------------------------------------------------------------------
 -- List Management
@@ -1565,39 +1742,9 @@ function TeleportPanel:ClearRows()
     wipe(self.teleportRows)
     self:ClearIcons()
     self:ClearHeaders()
+    self:ClearCards()
 end
 
---- Create a zone group header row
--- @param group table The group data with name, mapID, teleports
--- @param yOffset number Vertical offset for the header
--- @return Frame The created header frame
--- @return number The new yOffset after the header
-function TeleportPanel:CreateGroupHeader(group, yOffset)
-    local scrollChild = self.frame.scrollChild
-    local panelWidth = self.frame:GetWidth()
-
-    local header = self:GetHeaderFrame()
-    header:SetParent(scrollChild)
-    header:SetWidth(panelWidth - 50)
-    header:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", 0, -yOffset)
-    header:Show()
-
-    -- Zone name in gold
-    local zoneName = group.name
-    local continentKey = group.mapID and QR.GetContinentForZone and QR.GetContinentForZone(group.mapID)
-    local continentName = continentKey and QR.GetLocalizedContinentName and QR.GetLocalizedContinentName(continentKey)
-    if continentName then
-        header.zoneText:SetText(C.GOLD .. zoneName .. C.R .. "  " .. C.GRAY .. continentName .. C.R)
-    else
-        header.zoneText:SetText(C.GOLD .. zoneName .. C.R)
-    end
-
-    -- Count in gray
-    header.countText:SetText(C.GRAY .. string_format(L["TELEPORTS_COUNT"], #group.teleports) .. C.R)
-
-    table_insert(self.headerRows, header)
-    return header, yOffset + 24
-end
 
 --- Refresh the teleport list
 function TeleportPanel:RefreshList()
@@ -1642,18 +1789,14 @@ function TeleportPanel:RefreshList()
     local totalCount = 0
 
     if self.groupByDestination then
-        -- Grouped display with icon grid
+        -- Grouped display: one card per destination, in as many columns as the
+        -- window allows. Replaces the full-width header and icon grid a group
+        -- used to get, which cost 576px of height for eight groups.
         local groups = self:GroupTeleportsByDestination(filtered)
 
+        yOffset = self:CreateGroupCards(groups, yOffset)
+
         for _, group in ipairs(groups) do
-            -- Create group header
-            local _, newOffset = self:CreateGroupHeader(group, yOffset)
-            yOffset = newOffset
-
-            -- Icon grid instead of list rows
-            yOffset = self:CreateGroupIconRow(group, yOffset)
-
-            -- Count stats
             for _, entry in ipairs(group.teleports) do
                 totalCount = totalCount + 1
                 if entry.status == STATUS.READY or entry.status == STATUS.ON_CD or entry.status == STATUS.OWNED then

--- a/QuickRoute/Modules/TeleportPanel.lua
+++ b/QuickRoute/Modules/TeleportPanel.lua
@@ -1510,9 +1510,6 @@ end
 -- dot rather than a dot and a word, for the same reason.
 -------------------------------------------------------------------------------
 
---- How many cards fit across the panel.
--- @param panelWidth number The panel's current width
--- @return number At least one
 --- Texture coordinates that make a square icon cover a banner the way the
 -- design specifies ("beschnitten statt gestaucht", xMidYMid slice): the icon
 -- is scaled to the banner's width and the middle band shown, never squashed.
@@ -1534,6 +1531,9 @@ function TeleportPanel.BannerTexCoords(cardWidth, bannerHeight, iconSize)
     return 0, 1, band, 1 - band
 end
 
+--- How many cards fit across the panel.
+-- @param panelWidth number The panel's current width
+-- @return number At least one
 function TeleportPanel:CardsPerRow(panelWidth)
     local avail = (panelWidth or 0) - CARD_PADDING * 2
     local perRow = math_floor((avail + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP))

--- a/QuickRoute/Modules/TeleportPanel.lua
+++ b/QuickRoute/Modules/TeleportPanel.lua
@@ -761,15 +761,19 @@ function TeleportPanel:CreateContent(parentFrame)
     refreshButton:SetScript("OnLeave", GameTooltip_Hide)
     frame.refreshButton = refreshButton
 
-    -- Column headers
+    -- Column headers. They label the columns of the flat list; over the card
+    -- view they name nothing, so RefreshList hides them there. Kept on the
+    -- frame rather than created per refresh, like everything else here.
     local headerY = -32
     local nameHeader = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     nameHeader:SetPoint("TOPLEFT", PADDING + ICON_SIZE + 10, headerY)
     nameHeader:SetText(C.WHITE .. L["NAME"] .. C.R)
+    frame.nameHeader = nameHeader
 
     local statusHeader = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     statusHeader:SetPoint("TOPRIGHT", -PADDING - 5, headerY)
     statusHeader:SetText(C.WHITE .. L["STATUS"] .. C.R)
+    frame.statusHeader = statusHeader
 
     -- Header separator
     local headerSep = frame:CreateTexture(nil, "ARTWORK")
@@ -777,6 +781,7 @@ function TeleportPanel:CreateContent(parentFrame)
     headerSep:SetHeight(1)
     headerSep:SetPoint("TOPLEFT", PADDING, headerY - 12)
     headerSep:SetPoint("TOPRIGHT", -PADDING, headerY - 12)
+    frame.headerSep = headerSep
 
     -- Create scroll frame for teleport list
     local scrollFrame = CreateFrame("ScrollFrame", "QRTeleportScrollFrame", frame, "UIPanelScrollFrameTemplate")
@@ -1797,6 +1802,14 @@ function TeleportPanel:RefreshList()
     local readyCount = 0
     local ownedCount = 0
     local totalCount = 0
+
+    -- The column headers belong to the flat list. Over cards they label
+    -- nothing -- visible in a render of the card view as a stray "Name" and
+    -- "Status" floating above the first row.
+    local showColumnHeaders = not self.groupByDestination
+    if self.frame.nameHeader then self.frame.nameHeader:SetShown(showColumnHeaders) end
+    if self.frame.statusHeader then self.frame.statusHeader:SetShown(showColumnHeaders) end
+    if self.frame.headerSep then self.frame.headerSep:SetShown(showColumnHeaders) end
 
     if self.groupByDestination then
         -- Grouped display: one card per destination, in as many columns as the

--- a/QuickRoute/Modules/TeleportPanel.lua
+++ b/QuickRoute/Modules/TeleportPanel.lua
@@ -1578,8 +1578,12 @@ end
 --- Give a card back, and its icon frames with it.
 function TeleportPanel:ReleaseCardFrame(card)
     if not card then return end
+    -- The icons are let go of, not released: ClearIcons owns that, and doing
+    -- it here as well returned each frame to the pool twice.
     for _, iconFrame in ipairs(card.iconFrames or {}) do
-        self:ReleaseIconFrame(iconFrame)
+        iconFrame:Hide()
+        iconFrame:SetParent(nil)
+        iconFrame:ClearAllPoints()
     end
     if card.iconFrames then wipe(card.iconFrames) end
     card:Hide()
@@ -1640,6 +1644,12 @@ function TeleportPanel:ConfigureCard(card, group, cardWidth)
             CARD_PADDING + (i - 1) * (GRID_ICON_SIZE + GRID_ICON_GAP), CARD_PADDING)
         iconFrame:Show()
         self:ConfigureGridIcon(iconFrame, entry)
+        -- Two lists, one owner. The card holds references so it can hide them
+        -- with itself; releasing them back to the pool is the panel's job,
+        -- through ClearIcons. Doing it in both places put the same frame into
+        -- iconPool twice -- measured: three icons built, six pool entries,
+        -- three duplicates, and the next GetIconFrame handing one frame to two
+        -- callers.
         table_insert(card.iconFrames, iconFrame)
         table_insert(self.iconFrames, iconFrame)
         shown = i

--- a/QuickRoute/Modules/TeleportPanel.lua
+++ b/QuickRoute/Modules/TeleportPanel.lua
@@ -72,10 +72,14 @@ local PADDING = 10
 -- round number.
 local CARD_MIN_WIDTH = 254
 local CARD_GAP = 12
-local CARD_PADDING = 8
-local CARD_ICON_SIZE = 36
-local CARD_HEIGHT = 94
+local CARD_PADDING = 10
+-- K2 from the design canvas: a 68px picture banner carrying the name and the
+-- continent, then a foot with the teleport icons and a status dot.
+local CARD_BANNER_HEIGHT = 68
+local CARD_FOOT_HEIGHT = 56          -- CARD_PADDING + 36px icons + CARD_PADDING
+local CARD_HEIGHT = CARD_BANNER_HEIGHT + CARD_FOOT_HEIGHT
 local CARD_DOT_SIZE = 8
+local CARD_ICON_SOURCE_SIZE = 64     -- WoW icons are 64x64
 
 local GRID_ICON_SIZE = 36
 local GRID_ICON_GAP = 4
@@ -792,7 +796,10 @@ function TeleportPanel:CreateContent(parentFrame)
 
     -- Content frame inside scroll frame
     local scrollChild = CreateFrame("Frame", nil, scrollFrame)
-    scrollChild:SetSize(PANEL_MIN_WIDTH - 40, 1)
+    local window = QR.MainFrame and QR.MainFrame.frame
+    local contentWidth = window and window:GetWidth() or 0
+    if contentWidth < PANEL_MIN_WIDTH then contentWidth = PANEL_MIN_WIDTH end
+    scrollChild:SetSize(contentWidth - 40, 1)
     scrollFrame:SetScrollChild(scrollChild)
     frame.scrollChild = scrollChild
 
@@ -1506,6 +1513,27 @@ end
 --- How many cards fit across the panel.
 -- @param panelWidth number The panel's current width
 -- @return number At least one
+--- Texture coordinates that make a square icon cover a banner the way the
+-- design specifies ("beschnitten statt gestaucht", xMidYMid slice): the icon
+-- is scaled to the banner's width and the middle band shown, never squashed.
+-- A banner taller than the scaled icon shows the whole icon.
+-- @param cardWidth number
+-- @param bannerHeight number
+-- @param iconSize number Source icon edge in pixels (WoW: 64)
+-- @return number, number, number, number left, right, top, bottom
+function TeleportPanel.BannerTexCoords(cardWidth, bannerHeight, iconSize)
+    iconSize = iconSize or CARD_ICON_SOURCE_SIZE
+    if not cardWidth or not bannerHeight or cardWidth <= 0 or bannerHeight <= 0 then
+        return 0, 1, 0, 1
+    end
+    local visible = bannerHeight / cardWidth   -- the icon is scaled to cardWidth square
+    if visible >= 1 then
+        return 0, 1, 0, 1
+    end
+    local band = (1 - visible) / 2
+    return 0, 1, band, 1 - band
+end
+
 function TeleportPanel:CardsPerRow(panelWidth)
     local avail = (panelWidth or 0) - CARD_PADDING * 2
     local perRow = math_floor((avail + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP))
@@ -1542,37 +1570,56 @@ end
 function TeleportPanel:GetCardFrame()
     local card = table.remove(self.cardPool)
     if not card then
-        card = CreateFrame("Frame", nil, nil)
+        card = CreateFrame("Frame", nil, nil, "BackdropTemplate")
         card:SetHeight(CARD_HEIGHT)
+        card:SetBackdrop({
+            bgFile = "Interface\\Buttons\\WHITE8x8",
+            edgeFile = "Interface\\Buttons\\WHITE8x8",
+            edgeSize = 1,
+        })
+        card:SetBackdropColor(0.082, 0.086, 0.110, 1)        -- #15161c
+        card:SetBackdropBorderColor(0.239, 0.227, 0.200, 1)  -- #3d3a33
 
-        local bg = card:CreateTexture(nil, "BACKGROUND")
-        bg:SetAllPoints()
-        bg:SetColorTexture(0.12, 0.12, 0.14, 0.85)
-        card.bg = bg
+        -- The picture: the group's icon scaled to the card's width and cut to
+        -- the banner's height (ConfigureCard sets the band).
+        local banner = card:CreateTexture(nil, "ARTWORK")
+        banner:SetPoint("TOPLEFT", card, "TOPLEFT", 1, -1)
+        banner:SetPoint("TOPRIGHT", card, "TOPRIGHT", -1, -1)
+        banner:SetHeight(CARD_BANNER_HEIGHT)
+        card.banner = banner
 
-        local icon = card:CreateTexture(nil, "ARTWORK")
-        icon:SetSize(CARD_ICON_SIZE, CARD_ICON_SIZE)
-        icon:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PADDING, -CARD_PADDING)
-        card.icon = icon
+        -- Darkens towards the bottom so the name stays readable on any picture.
+        local scrim = card:CreateTexture(nil, "ARTWORK", nil, 1)
+        scrim:SetAllPoints(banner)
+        scrim:SetColorTexture(1, 1, 1, 1)
+        scrim:SetGradient("VERTICAL", CreateColor(0.03, 0.035, 0.055, 0.92), CreateColor(0.03, 0.035, 0.055, 0.06))
+        card.scrim = scrim
 
-        -- Stacked, not side by side: at a card's width they collide.
-        local nameText = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-        nameText:SetPoint("TOPLEFT", icon, "TOPRIGHT", 8, -2)
-        nameText:SetPoint("RIGHT", card, "RIGHT", -CARD_PADDING, 0)
-        nameText:SetJustifyH("LEFT")
-        nameText:SetWordWrap(false)
-        card.nameText = nameText
-
+        -- Name over continent, both at the banner's bottom-left, stacked: at a
+        -- card's width they collide side by side.
         local contText = card:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-        contText:SetPoint("TOPLEFT", nameText, "BOTTOMLEFT", 0, -2)
-        contText:SetPoint("RIGHT", card, "RIGHT", -CARD_PADDING, 0)
+        contText:SetPoint("BOTTOMLEFT", banner, "BOTTOMLEFT", CARD_PADDING, 5)
+        contText:SetPoint("RIGHT", banner, "RIGHT", -CARD_PADDING, 0)
         contText:SetJustifyH("LEFT")
         contText:SetWordWrap(false)
+        contText:SetShadowOffset(0, -1)
+        contText:SetShadowColor(0, 0, 0, 0.95)
         card.contText = contText
 
+        local nameText = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        nameText:SetFont(STANDARD_TEXT_FONT, 14, "")
+        nameText:SetPoint("BOTTOMLEFT", contText, "TOPLEFT", 0, 1)
+        nameText:SetPoint("RIGHT", banner, "RIGHT", -CARD_PADDING, 0)
+        nameText:SetJustifyH("LEFT")
+        nameText:SetWordWrap(false)
+        nameText:SetShadowOffset(0, -1)
+        nameText:SetShadowColor(0, 0, 0, 0.95)
+        card.nameText = nameText
+
+        -- Round status dot, right end of the foot, on the icons' centre line.
         local dot = card:CreateTexture(nil, "OVERLAY")
         dot:SetSize(CARD_DOT_SIZE, CARD_DOT_SIZE)
-        dot:SetPoint("BOTTOMRIGHT", card, "BOTTOMRIGHT", -CARD_PADDING, CARD_PADDING + 14)
+        dot:SetPoint("BOTTOMRIGHT", card, "BOTTOMRIGHT", -CARD_PADDING, (CARD_FOOT_HEIGHT - CARD_DOT_SIZE) / 2)
         card.dot = dot
 
         card.iconFrames = {}
@@ -1605,14 +1652,14 @@ function TeleportPanel:ClearCards()
     self.cards = {}
 end
 
---- Colour of the status dot for a group, taken from its best entry.
-local function GroupStatusColor(group)
+--- The status dot for a group, taken from its best entry: a round indicator
+-- texture, green when ready, yellow on cooldown, grey otherwise.
+local function GroupStatusDot(group)
     local best = group.teleports and group.teleports[1]
-    local status = best and best.status
-    if status == STATUS.READY then return 0.2, 0.9, 0.3 end
-    if status == STATUS.ON_CD then return 0.95, 0.75, 0.2 end
-    if status == STATUS.OWNED then return 0.6, 0.8, 1.0 end
-    return 0.5, 0.5, 0.5
+    local key = best and best.status and best.status.key
+    if key == "STATUS_READY" then return "Interface\\COMMON\\Indicator-Green" end
+    if key == "STATUS_ON_CD" then return "Interface\\COMMON\\Indicator-Yellow" end
+    return "Interface\\COMMON\\Indicator-Gray"
 end
 
 --- Fill one card for one group.
@@ -1626,8 +1673,9 @@ function TeleportPanel:ConfigureCard(card, group, cardWidth)
     -- the icon of the group's first-sorted teleport -- which always resolves,
     -- and is visibly different between hearthstones, portals and toys.
     local best = group.teleports and group.teleports[1]
-    card.icon:SetTexture(best and GetIconTexture(best)
+    card.banner:SetTexture(best and GetIconTexture(best)
         or "Interface\\Icons\\INV_Misc_QuestionMark")
+    card.banner:SetTexCoord(TeleportPanel.BannerTexCoords(cardWidth, CARD_BANNER_HEIGHT, CARD_ICON_SOURCE_SIZE))
 
     card.nameText:SetText(C.GOLD .. tostring(group.name or "?") .. C.R)
 
@@ -1637,7 +1685,7 @@ function TeleportPanel:ConfigureCard(card, group, cardWidth)
         and QR.GetLocalizedContinentName(continentKey)
     card.contText:SetText(C.GRAY .. (continentName or "") .. C.R)
 
-    card.dot:SetColorTexture(GroupStatusColor(group))
+    card.dot:SetTexture(GroupStatusDot(group))
 
     local maxIcons = self:IconsPerCard(cardWidth)
     local shown = 0
@@ -1744,7 +1792,9 @@ function TeleportPanel:GetRowFrame()
     local row = table.remove(self.rowPool)
     if not row then
         row = CreateFrame("Frame", nil, nil)
-        row:SetSize(PANEL_MIN_WIDTH - 50, ROW_HEIGHT)
+        local panelWidth = self.frame and self.frame:GetWidth() or 0
+        if panelWidth < PANEL_MIN_WIDTH then panelWidth = PANEL_MIN_WIDTH end
+        row:SetSize(panelWidth - 50, ROW_HEIGHT)
     end
     return row
 end

--- a/QuickRoute/Modules/UI.lua
+++ b/QuickRoute/Modules/UI.lua
@@ -427,7 +427,11 @@ function UI:CreateContent(parentFrame)
 
     -- Content frame inside scroll frame
     local scrollChild = CreateFrame("Frame", nil, scrollFrame)
-    scrollChild:SetSize(FRAME_MIN_WIDTH - 50, 1)
+    -- Follows the window: at 820 the route tab is 770 wide, not the old minimum.
+    local window = QR.MainFrame and QR.MainFrame.frame
+    local contentWidth = window and window:GetWidth() or 0
+    if contentWidth < FRAME_MIN_WIDTH then contentWidth = FRAME_MIN_WIDTH end
+    scrollChild:SetSize(contentWidth - 50, 1)
     scrollFrame:SetScrollChild(scrollChild)
     frame.scrollChild = scrollChild
 

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -406,6 +406,9 @@ local function CreateMockFontString(parent)
         _size = { w = 0, h = 12 },  -- Default font height
         _wordWrap = true,
     }
+    -- Real regions have SetShown, and so does the simulator; the mock only
+    -- had it on frames and textures, so hiding a FontString by mode threw.
+    function fs:SetShown(show) if show then self:Show() else self:Hide() end end
     function fs:SetText(text) self._text = text or "" end
     function fs:GetText() return self._text end
     function fs:SetPoint(point, ...) self._points[#self._points + 1] = { point, ... } end

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -387,7 +387,8 @@ local function CreateMockTexture(parent)
     function tex:Hide() self._shown = false end
     function tex:SetShown(show) if show then self:Show() else self:Hide() end end
     function tex:IsShown() return self._shown end
-    function tex:SetTexCoord() end
+    function tex:SetTexCoord(...) self._texCoord = { ... } end
+    function tex:GetTexCoord() if self._texCoord then return unpack(self._texCoord) end end
     function tex:SetVertexColor(r, g, b, a) self._vertexColor = { r, g, b, a } end
     function tex:SetGradient(orientation, minColor, maxColor) self._gradient = { orientation, minColor, maxColor } end
     function tex:SetAlpha(alpha) self._alpha = alpha end

--- a/tests/test_teleportpanel.lua
+++ b/tests/test_teleportpanel.lua
@@ -1195,3 +1195,43 @@ T:run("ClearCards: cards and their icons both go back to the pools", function(t)
 
     QR.TeleportPanel:ClearIcons()
 end)
+
+T:run("ClearCards: an icon frame reaches the pool exactly once", function(t)
+    resetState()
+    ensureTeleportPanelFrame()
+    QR.TeleportPanel.frame:SetWidth(820)
+    QR.TeleportPanel.iconPool = {}
+    QR.TeleportPanel.iconFrames = {}
+    QR.TeleportPanel.cardPool = {}
+    QR.TeleportPanel.cards = {}
+
+    local teleports = {}
+    for i = 1, 3 do
+        teleports[i] = {
+            id = 6940 + i,
+            data = { name = "T" .. i, destination = "Dalaran" },
+            isSpell = false,
+            status = { sortOrder = 1, color = "|cFF00FF00", text = "Ready", key = "STATUS_READY" },
+            cooldownRemaining = 0,
+        }
+    end
+    QR.TeleportPanel:CreateGroupCards({ { name = "Dalaran", mapID = 125,
+        teleports = teleports } }, 0)
+
+    -- Both clearing calls, in the order RefreshList makes them. The card holds
+    -- its icons but does not release them; ClearIcons owns that. When both did
+    -- it, three icons produced six pool entries and the next GetIconFrame
+    -- handed the same frame to two callers.
+    QR.TeleportPanel:ClearIcons()
+    QR.TeleportPanel:ClearCards()
+
+    t:assertEqual(3, #QR.TeleportPanel.iconPool,
+        "three icons built, three in the pool")
+
+    local seen, duplicates = {}, 0
+    for _, frame in ipairs(QR.TeleportPanel.iconPool) do
+        if seen[frame] then duplicates = duplicates + 1 end
+        seen[frame] = true
+    end
+    t:assertEqual(0, duplicates, "and none of them twice")
+end)

--- a/tests/test_teleportpanel.lua
+++ b/tests/test_teleportpanel.lua
@@ -1263,3 +1263,73 @@ T:run("RefreshList: the column headers belong to the list, not the cards", funct
     QR.TeleportPanel:ClearCards()
     QR.TeleportPanel:ClearIcons()
 end)
+
+-------------------------------------------------------------------------------
+-- K2 picture cards: banner crop, card anatomy, card height
+-------------------------------------------------------------------------------
+
+T:run("BannerTexCoords: a 254px card shows the middle band of the icon (xMidYMid slice)", function(t)
+    local l, r, top, bottom = QR.TeleportPanel.BannerTexCoords(254, 68, 64)
+    t:assertEqual(0, l)
+    t:assertEqual(1, r)
+    t:assertTrue(math.abs(top - 0.366) < 0.002, "top of the band, got " .. tostring(top))
+    t:assertTrue(math.abs(bottom - 0.634) < 0.002, "bottom of the band, got " .. tostring(bottom))
+end)
+
+T:run("BannerTexCoords: the band is symmetric and never squashes", function(t)
+    local _, _, top, bottom = QR.TeleportPanel.BannerTexCoords(100, 68, 64)
+    t:assertTrue(math.abs((1 - bottom) - top) < 1e-9, "centred band")
+    t:assertTrue(math.abs((bottom - top) - 0.68) < 1e-9, "the visible fraction is height over width")
+end)
+
+T:run("BannerTexCoords: a banner taller than the scaled icon shows the whole icon", function(t)
+    local l, r, top, bottom = QR.TeleportPanel.BannerTexCoords(50, 68, 64)
+    t:assertEqual(0, top)
+    t:assertEqual(1, bottom)
+    t:assertEqual(0, l)
+    t:assertEqual(1, r)
+    local _, _, t2, b2 = QR.TeleportPanel.BannerTexCoords(nil, 68, 64)
+    t:assertEqual(0, t2)
+    t:assertEqual(1, b2)
+end)
+
+T:run("Card: has a picture banner, a scrim, stacked texts and a status dot", function(t)
+    resetState()
+    QR.TeleportPanel.cardPool = {}
+    local card = QR.TeleportPanel:GetCardFrame()
+    t:assertNotNil(card.banner, "banner texture")
+    t:assertNotNil(card.scrim, "scrim over the banner")
+    t:assertNotNil(card.scrim._gradient, "the scrim is a gradient")
+    t:assertNotNil(card.nameText, "name")
+    t:assertNotNil(card.contText, "continent")
+    t:assertNotNil(card.dot, "status dot")
+    t:assertNil(card.icon, "no 36px corner icon: the banner is the picture")
+end)
+
+T:run("Card: ConfigureCard crops the banner and picks the round dot by status", function(t)
+    resetState()
+    ensureTeleportPanelFrame()
+    QR.TeleportPanel.cardPool = {}
+    QR.TeleportPanel.iconFrames = {}
+    local group = { name = "Dalaran", mapID = 627, teleports = {
+        { id = 140192, isSpell = false, data = { name = "Dalaran Hearthstone", mapID = 627 },
+          status = { sortOrder = 1, color = "|cFF00FF00", text = "Ready", key = "STATUS_READY" }, cooldownRemaining = 0 },
+    } }
+    local card = QR.TeleportPanel:GetCardFrame()
+    QR.TeleportPanel:ConfigureCard(card, group, 254)
+    local _, _, top, bottom = card.banner:GetTexCoord()
+    t:assertTrue(top > 0.3 and bottom < 0.7, "banner shows the middle band")
+    t:assertEqual("Interface\\COMMON\\Indicator-Green", card.dot:GetTexture(), "ready -> green dot")
+    t:assertNotNil(card.nameText:GetText():find("Dalaran", 1, true), "name in the banner")
+end)
+
+T:run("CreateGroupCards: a row is a 124px card plus the gap", function(t)
+    resetState()
+    ensureTeleportPanelFrame()
+    QR.TeleportPanel.cardPool = {}
+    QR.TeleportPanel.cards = {}
+    QR.TeleportPanel.iconFrames = {}
+    local group = { name = "Dalaran", mapID = 627, teleports = {} }
+    local newYOffset = QR.TeleportPanel:CreateGroupCards({ group }, 0)
+    t:assertEqual(124 + 12, newYOffset, "68px banner + 56px foot, then the 12px gap")
+end)

--- a/tests/test_teleportpanel.lua
+++ b/tests/test_teleportpanel.lua
@@ -813,24 +813,30 @@ T:run("CreateGroupIconRow: icons laid out in grid", function(t)
         },
     }
 
-    local newYOffset = QR.TeleportPanel:CreateGroupIconRow(group, 0)
+    -- The grouped view draws a card per destination now; the icons live along
+    -- the foot of the card instead of in a full-width grid below a header.
+    -- The width is set here rather than taken from whatever the mock frame
+    -- happens to report, because it is what the layout is being tested on.
+    QR.TeleportPanel.frame:SetWidth(820)
+    local newYOffset = QR.TeleportPanel:CreateGroupCards({ group }, 0)
     t:assertEqual(3, #QR.TeleportPanel.iconFrames, "3 icon frames created")
     t:assertGreaterThan(newYOffset, 0, "yOffset advanced")
+    t:assertEqual(1, #QR.TeleportPanel.cards, "one card for one group")
 
-    -- Verify all icons are shown
     for i, icon in ipairs(QR.TeleportPanel.iconFrames) do
         t:assertTrue(icon:IsShown(), "Icon " .. i .. " is shown")
     end
 
+    QR.TeleportPanel:ClearCards()
     QR.TeleportPanel:ClearIcons()
 end)
 
-T:run("CreateGroupIconRow: wraps to next row when full", function(t)
+T:run("CreateGroupCards: a group with more teleports than fit says how many are hidden", function(t)
     resetState()
     ensureTeleportPanelFrame()
 
-    -- Panel width ~500, avail ~450. At 36+4=40px per icon, fits ~11 per row
-    -- Create 15 icons to force wrap
+    -- A card is narrower than the panel, so 15 teleports cannot all show. The
+    -- ones that do not fit are stated on the card rather than dropped silently.
     local teleports = {}
     for i = 1, 15 do
         table.insert(teleports, {
@@ -844,13 +850,23 @@ T:run("CreateGroupIconRow: wraps to next row when full", function(t)
     end
 
     local group = { name = "Dalaran", mapID = 125, teleports = teleports }
-    local newYOffset = QR.TeleportPanel:CreateGroupIconRow(group, 0)
+    QR.TeleportPanel.frame:SetWidth(820)
+    local newYOffset = QR.TeleportPanel:CreateGroupCards({ group }, 0)
 
-    t:assertEqual(15, #QR.TeleportPanel.iconFrames, "15 icon frames created")
-    -- With 2 rows (11+4), height should be more than one row of icons
-    -- One row: 6+36+6 = 48, two rows: 6 + 36 + 4 + 36 + 6 = 88
-    t:assertGreaterThan(newYOffset, 48, "yOffset reflects multiple rows")
+    local cardWidth = QR.TeleportPanel:CardWidth(QR.TeleportPanel.frame:GetWidth())
+    local fit = QR.TeleportPanel:IconsPerCard(cardWidth)
+    t:assertTrue(fit < 15, "15 teleports do not all fit on one card (" .. fit .. ")")
+    t:assertEqual(fit, #QR.TeleportPanel.iconFrames, "only the ones that fit get a frame")
+    t:assertGreaterThan(newYOffset, 0, "yOffset advanced")
 
+    local card = QR.TeleportPanel.cards[1]
+    t:assertNotNil(card, "a card was made")
+    if card then
+        t:assertNotNil(card.contText:GetText():match("%+" .. (15 - fit)),
+            "the card says how many are not shown")
+    end
+
+    QR.TeleportPanel:ClearCards()
     QR.TeleportPanel:ClearIcons()
 end)
 
@@ -1106,4 +1122,76 @@ T:run("Zone restriction: the beacon counts as owned on a Throne of Thunder floor
     t:assertNotNil(entry, "The beacon is listed")
     t:assertTrue(entry.status.key ~= "STATUS_ZONE", "Inside the restriction the zone status does not apply")
     t:assertTrue(entry.status.key ~= "STATUS_MISSING", "The owned toy is not reported missing")
+end)
+
+-------------------------------------------------------------------------------
+-- Card layout
+--
+-- The design is explicit that the column count must follow the window width
+-- rather than being hard-coded: at the panel minimum of 500 a 254-wide card
+-- leaves nothing for an icon, a name and a status. These pin the arithmetic,
+-- which is the part of the design that can be checked without seeing it.
+-------------------------------------------------------------------------------
+
+T:run("CardsPerRow: the column count follows the window", function(t)
+    local TP = QR.TeleportPanel
+    t:assertEqual(1, TP:CardsPerRow(500), "one column at the panel minimum")
+    t:assertEqual(2, TP:CardsPerRow(540), "two once there is room for two")
+    t:assertEqual(3, TP:CardsPerRow(820), "three at the width the design was drawn at")
+    t:assertEqual(4, TP:CardsPerRow(1200), "and it keeps going")
+end)
+
+T:run("CardsPerRow: never fewer than one, whatever it is given", function(t)
+    local TP = QR.TeleportPanel
+    t:assertEqual(1, TP:CardsPerRow(0), "zero width")
+    t:assertEqual(1, TP:CardsPerRow(-100), "negative width")
+    t:assertEqual(1, TP:CardsPerRow(nil), "no width at all")
+end)
+
+T:run("CardWidth: cards divide the row without spilling out of it", function(t)
+    local TP = QR.TeleportPanel
+    for _, panel in ipairs({500, 540, 760, 820, 1200}) do
+        local width, perRow = TP:CardWidth(panel)
+        -- Every card, plus the gaps between them, plus the padding either side.
+        local used = perRow * width + (perRow - 1) * 12 + 16
+        t:assertTrue(used <= panel + 0.5,
+            string.format("at %d: %d card(s) of %.1f fit in %d (used %.1f)",
+                panel, perRow, width, panel, used))
+        t:assertTrue(width > 0, "and the card has a width at " .. panel)
+    end
+end)
+
+T:run("IconsPerCard: the status dot keeps its place", function(t)
+    local TP = QR.TeleportPanel
+    -- A card at the design's own width takes five icons, which is what the
+    -- design says. Fewer than that and the dot would be pushed off the card.
+    t:assertEqual(5, TP:IconsPerCard(254), "five at the design's card width")
+    t:assertEqual(1, TP:IconsPerCard(0), "never fewer than one")
+    t:assertEqual(1, TP:IconsPerCard(nil), "even with no width")
+end)
+
+T:run("ClearCards: cards and their icons both go back to the pools", function(t)
+    resetState()
+    ensureTeleportPanelFrame()
+    QR.TeleportPanel.frame:SetWidth(820)
+    QR.TeleportPanel.cardPool = {}
+    QR.TeleportPanel.cards = {}
+    QR.TeleportPanel.iconFrames = {}
+
+    local group = {
+        name = "Dalaran", mapID = 125,
+        teleports = {
+            { id = 6948, data = { name = "Hearthstone", destination = "Dalaran" },
+              isSpell = false, status = { sortOrder = 1, color = "|cFF00FF00",
+              text = "Ready", key = "STATUS_READY" }, cooldownRemaining = 0 },
+        },
+    }
+    QR.TeleportPanel:CreateGroupCards({ group }, 0)
+    t:assertEqual(1, #QR.TeleportPanel.cards, "one card on screen")
+
+    QR.TeleportPanel:ClearCards()
+    t:assertEqual(0, #QR.TeleportPanel.cards, "none after clearing")
+    t:assertEqual(1, #QR.TeleportPanel.cardPool, "and it went back to the pool")
+
+    QR.TeleportPanel:ClearIcons()
 end)

--- a/tests/test_teleportpanel.lua
+++ b/tests/test_teleportpanel.lua
@@ -1235,3 +1235,31 @@ T:run("ClearCards: an icon frame reaches the pool exactly once", function(t)
     end
     t:assertEqual(0, duplicates, "and none of them twice")
 end)
+
+T:run("RefreshList: the column headers belong to the list, not the cards", function(t)
+    resetState()
+    ensureTeleportPanelFrame()
+    QR.TeleportPanel.frame:SetWidth(820)
+
+    -- Rendered proof this was needed: a screenshot of the card view showed a
+    -- stray "Name" and "Status" floating above the first row of cards, left
+    -- over from the flat list they label.
+    QR.TeleportPanel.groupByDestination = true
+    QR.TeleportPanel:RefreshList()
+    t:assertFalse(QR.TeleportPanel.frame.nameHeader:IsShown(),
+        "no Name column over cards")
+    t:assertFalse(QR.TeleportPanel.frame.statusHeader:IsShown(),
+        "no Status column over cards")
+    t:assertFalse(QR.TeleportPanel.frame.headerSep:IsShown(),
+        "and no separator under them")
+
+    QR.TeleportPanel.groupByDestination = false
+    QR.TeleportPanel:RefreshList()
+    t:assertTrue(QR.TeleportPanel.frame.nameHeader:IsShown(),
+        "but they are back over the flat list")
+    t:assertTrue(QR.TeleportPanel.frame.statusHeader:IsShown(), "both of them")
+    t:assertTrue(QR.TeleportPanel.frame.headerSep:IsShown(), "separator too")
+
+    QR.TeleportPanel:ClearCards()
+    QR.TeleportPanel:ClearIcons()
+end)


### PR DESCRIPTION
Implements **K2** from the design canvas "QuickRoute Teleport-Inventar": one picture card per destination in the grouped view, three columns at the width the design was drawn at.

## The card, as drawn

A 68px banner across the top carries the group's icon, scaled to the card's width and cropped to the banner rather than squashed: the banner shows the middle band of the icon (`BannerTexCoords`), so a square icon fills a 254px wide banner without distortion. The destination name and its continent sit stacked over a dark scrim in the banner's lower-left. Below it a 56px foot holds the teleport icons and, on the right, a round status dot (green ready, yellow on cooldown, grey otherwise). A group with more teleports than fit says `+n` rather than dropping them silently.

## The window opens at 820px

Three cards per row need the width the design was drawn at, so the main window opens at 820px instead of 500px. That is a product decision this PR makes and the changelog names; at the former 500px the cards fell into a single column. The route tab's scroll child and the card grid follow the window width instead of their 500px constants. The column count still follows the width, with the design's 254px card minimum:

| panel width | columns | card |
|---|---|---|
| 500 (`PANEL_MIN_WIDTH`) | 1 | 484 |
| 540 | 2 | 256 |
| 820 (default now) | 3 | 260 |
| 1200 | 4 | 287 |

## The destination icon comes from the source that always resolves

The design's own icon sheet lists three sources, in order: hand-drawn symbols for the 19 destinations with no `mapID`, 13 continent symbols, and the icon of the group's first-sorted teleport through `GetIconTexture`. Only the third exists, and the sheet says it always resolves; that is what the banner uses. It is a 64px icon enlarged to the card's width, so it is soft; the design accepted that in exchange for shipping before any symbol is drawn.

## What went, and what deliberately stayed

`CreateGroupHeader` and `CreateGroupIconRow` are gone; they are what this replaces. Their two tests are rewritten against the card layout rather than deleted. The header frame pool stays: it is generic, four tests cover it, and it should go once the cards are confirmed in game.

## Rendered

Rendered in the UI simulator against this branch; the render is in the PR conversation. The simulator answers one fallback icon and `Map <id>` for every destination it has no data for, so every banner shows the same picture there; in the client they differ per group.

## Tests

13799 pass. New for the cards: three `BannerTexCoords` cases, the card anatomy, the crop and dot choice in `ConfigureCard`, and the 124px row height, each seen to fail with the matching defect injected (no crop, no green dot, old card height). The earlier column-count, `IconsPerCard` and `+n` tests stay and were verified the same way. The test double gains `SetTexCoord`, `SetGradient`, `CreateColor`, `STANDARD_TEXT_FONT` and text shadows.

## Rebased onto main

The zone-locked-beacon fix ([#47](https://github.com/CybotTM/wow-quickroute/pull/47)) and the settings header ([#48](https://github.com/CybotTM/wow-quickroute/pull/48)) were carried on this branch as cherry-picks while both were open; after their merges the branch was rebased and those commits dropped out, so the diff is the cards alone. The reporter's install runs this tree as `1.15.0+cards3`.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
