### PR TITLE
fix: add the General section header to the settings layout

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,6 +29,7 @@ globals = {
 
     -- WoW API namespaces
     "C_AddOns",
+    "C_XMLUtil",
     "C_Map",
     "C_Container",
     "C_Spell",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -87,6 +87,7 @@ globals = {
     "PlaySound",
     "Screenshot",
     "hooksecurefunc",
+    "CreateSettingsListSectionHeaderInitializer",
     "seterrorhandler",
     "geterrorhandler",
     "debugstack",

--- a/QuickRoute/Modules/SettingsPanel.lua
+++ b/QuickRoute/Modules/SettingsPanel.lua
@@ -97,9 +97,16 @@ end
 local function RegisterNativeSettings()
     L = QR.L
 
-    local category = Settings.RegisterVerticalLayoutCategory(
+    -- The layout is the second return value, and it is what anything other
+    -- than a checkbox, slider or dropdown has to be added to. Those three take
+    -- the category and register themselves; a section header does not, so it
+    -- needs AddInitializer or it is simply built and dropped -- which is what
+    -- used to happen here, leaving ten translations of SETTINGS_GENERAL with
+    -- nowhere to appear.
+    local category, layout = Settings.RegisterVerticalLayoutCategory(
         L["ADDON_TITLE"] or "QuickRoute"
     )
+    SettingsPanel.layout = layout
 
     -- The header element ("C2" on the design canvas) comes first; the global
     -- SettingsPanel is Blizzard's frame, not this module.
@@ -111,7 +118,9 @@ local function RegisterNativeSettings()
     end
 
     -- General
-    Settings.CreateElementInitializer("SettingsListSectionHeaderTemplate", { name = L["SETTINGS_GENERAL"] })
+    if layout and CreateSettingsListSectionHeaderInitializer then
+        layout:AddInitializer(CreateSettingsListSectionHeaderInitializer(L["SETTINGS_GENERAL"]))
+    end
 
     RegisterCheckbox(category,
         L["SETTINGS_SHOW_MINIMAP"] or "Show Minimap Button",

--- a/QuickRoute/Modules/SettingsPanel.lua
+++ b/QuickRoute/Modules/SettingsPanel.lua
@@ -108,10 +108,13 @@ local function RegisterNativeSettings()
     )
     SettingsPanel.layout = layout
 
-    -- The header element ("C2" on the design canvas) comes first; the global
-    -- SettingsPanel is Blizzard's frame, not this module.
-    local layout = _G.SettingsPanel and _G.SettingsPanel.GetLayout
-        and _G.SettingsPanel:GetLayout(category)
+    -- The header element ("C2" on the design canvas) comes first. Should the
+    -- category not bring its layout along, ask Blizzard's SettingsPanel frame
+    -- (the global, not this module) for it.
+    if not layout and _G.SettingsPanel and _G.SettingsPanel.GetLayout then
+        layout = _G.SettingsPanel:GetLayout(category)
+        SettingsPanel.layout = layout
+    end
     if layout then
         SettingsPanel.headerInitializer = Settings.CreateElementInitializer("QuickRouteSettingsHeaderTemplate", {})
         layout:AddInitializer(SettingsPanel.headerInitializer)

--- a/QuickRoute/Modules/SettingsPanel.lua
+++ b/QuickRoute/Modules/SettingsPanel.lua
@@ -115,7 +115,12 @@ local function RegisterNativeSettings()
         layout = _G.SettingsPanel:GetLayout(category)
         SettingsPanel.layout = layout
     end
-    if layout then
+    -- Only when the client knows the template: the settings list asks for
+    -- its extent while laying out, and an unknown template is an error that
+    -- takes the whole page down (seen in game with a TOC that lacked the XML).
+    local headerKnown = C_XMLUtil and C_XMLUtil.GetTemplateInfo
+        and C_XMLUtil.GetTemplateInfo("QuickRouteSettingsHeaderTemplate") ~= nil
+    if layout and headerKnown then
         SettingsPanel.headerInitializer = Settings.CreateElementInitializer("QuickRouteSettingsHeaderTemplate", {})
         layout:AddInitializer(SettingsPanel.headerInitializer)
     end

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -822,6 +822,12 @@ function MockWoW:Install()
     end
 
     -- wipe (clears a table in-place)
+    -- A plain global, not a Settings member -- this is the documented helper
+    -- for a section header in a vertical layout.
+    _G.CreateSettingsListSectionHeaderInitializer = function(name)
+        return { _type = "sectionHeader", _name = name }
+    end
+
     _G.wipe = function(t)
         if type(t) == "table" then
             for k in pairs(t) do
@@ -1649,8 +1655,20 @@ function MockWoW:Install()
         RegisterAddOnCategory = function(category) end,
         OpenToCategory = function(id) end,
         -- Native vertical layout API (WoW 11.0+)
+        -- Returns the category AND its layout. The second value is what a
+        -- custom element has to be added to; returning only the first made a
+        -- discarded initializer indistinguishable from a used one.
         RegisterVerticalLayoutCategory = function(name)
-            return { GetID = function() return name end, _name = name }
+            local layout = {
+                _initializers = {},
+                AddInitializer = function(self, initializer)
+                    table.insert(self._initializers, initializer)
+                    return initializer
+                end,
+            }
+            local category = { GetID = function() return name end, _name = name,
+                               _layout = layout }
+            return category, layout
         end,
         RegisterProxySetting = function(category, variable, varType, name, defaultValue, getValue, setValue)
             return {

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -1726,6 +1726,14 @@ function MockWoW:Install()
         end,
     }
 
+    -- Templates the addon's XML declares; the settings list asks for their
+    -- extent, and an unknown one is an error there.
+    _G.C_XMLUtil = _G.C_XMLUtil or {}
+    _G.C_XMLUtil.GetTemplateInfo = function(name)
+        if cfg.unknownTemplates and cfg.unknownTemplates[name] then return nil end
+        return { type = "Frame", width = 0, height = 236, keyValues = {} }
+    end
+
     _G.C_AddOns = _G.C_AddOns or {}
     _G.C_AddOns.GetAddOnMetadata = function(name, field)
         local meta = cfg.addonMetadata and cfg.addonMetadata[name]

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -1659,15 +1659,11 @@ function MockWoW:Install()
         -- custom element has to be added to; returning only the first made a
         -- discarded initializer indistinguishable from a used one.
         RegisterVerticalLayoutCategory = function(name)
-            local layout = {
-                _initializers = {},
-                AddInitializer = function(self, initializer)
-                    table.insert(self._initializers, initializer)
-                    return initializer
-                end,
-            }
-            local category = { GetID = function() return name end, _name = name,
-                               _layout = layout }
+            -- The same layout SettingsPanel:GetLayout(category) hands out, as
+            -- in the client; two lookups must not yield two lists.
+            local category = { GetID = function() return name end, _name = name }
+            local layout = _G.SettingsPanel:GetLayout(category)
+            category._layout = layout
             return category, layout
         end,
         RegisterProxySetting = function(category, variable, varType, name, defaultValue, getValue, setValue)

--- a/tests/test_settingspanel.lua
+++ b/tests/test_settingspanel.lua
@@ -138,3 +138,19 @@ T:run("SettingsPanel: the General section header reaches the layout", function(t
     t:assertEqual(QR.L["SETTINGS_GENERAL"], found._name,
         "and it carries the localised name")
 end)
+
+T:run("SettingsPanel: without its template the header element stays out of the layout", function(t)
+    MockWoW:Reset()
+    MockWoW.config.unknownTemplates = { QuickRouteSettingsHeaderTemplate = true }
+    QR.SettingsPanel.initialized = false
+    QR.SettingsPanel.category = nil
+    QR.SettingsPanel.layout = nil
+    QR.SettingsPanel.headerInitializer = nil
+    QR.SettingsPanel:Initialize()
+    MockWoW.config.unknownTemplates = nil
+
+    t:assertNil(QR.SettingsPanel.headerInitializer, "no initializer for a template the client does not know")
+    for _, init in ipairs(QR.SettingsPanel.layout._initializers or {}) do
+        t:assertTrue(init._template ~= "QuickRouteSettingsHeaderTemplate", "and none reached the layout")
+    end
+end)

--- a/tests/test_settingspanel.lua
+++ b/tests/test_settingspanel.lua
@@ -107,3 +107,34 @@ T:run("SettingsPanel: Open does not error", function(t)
     -- Should not error even without full WoW UI
     QR.SettingsPanel:Open()
 end)
+
+-------------------------------------------------------------------------------
+-- The section header
+--
+-- Settings.RegisterVerticalLayoutCategory returns the category AND its layout.
+-- Checkboxes, sliders and dropdowns take the category and register themselves;
+-- a section header does not, so it has to be handed to the layout. It used not
+-- to be: the initializer was built and the return value dropped, which left ten
+-- translations of SETTINGS_GENERAL with nowhere to appear. See issue #44.
+-------------------------------------------------------------------------------
+
+T:run("SettingsPanel: the General section header reaches the layout", function(t)
+    MockWoW:Reset()
+    QR.SettingsPanel.initialized = false
+    QR.SettingsPanel.category = nil
+    QR.SettingsPanel.layout = nil
+    QR.SettingsPanel:Initialize()
+
+    local layout = QR.SettingsPanel.layout
+    t:assertNotNil(layout, "the layout was captured, not thrown away")
+    if not layout then return end
+
+    local found
+    for _, init in ipairs(layout._initializers or {}) do
+        if init._type == "sectionHeader" then found = init end
+    end
+    t:assertNotNil(found, "a section header was added to the layout")
+    if not found then return end
+    t:assertEqual(QR.L["SETTINGS_GENERAL"], found._name,
+        "and it carries the localised name")
+end)


### PR DESCRIPTION
Closes [#44](https://github.com/CybotTM/wow-quickroute/issues/44).

## The header was built and thrown away

`Settings.RegisterVerticalLayoutCategory` returns the category **and its layout**, and the layout is what anything other than a checkbox, slider or dropdown has to be added to. Those three take the category and register themselves; a section header does not.

The code captured only the first return value, then called `Settings.CreateElementInitializer` and did nothing with the result. So the header never reached a layout, and ten translations of `SETTINGS_GENERAL` had nowhere to appear.

## Verified against the real client, not inferred

The issue was filed on reasoning: `CreateCheckbox(category, …)` takes a category, `CreateElementInitializer(template, data)` does not, so it cannot register itself. That is an inference about Blizzard's internals, and the issue said so.

It is now measured. Running the real Blizzard UI under [wow-ui-sim](https://github.com/Osso/wow-ui-sim):

```
layout        : table: 0x0000a949
AddInitializer: function: 0x0000604c
helper global : function: 0x00005d92
```

Two return values, `layout:AddInitializer` exists, and `CreateSettingsListSectionHeaderInitializer` is a plain global — which is the shape the Warcraft Wiki's "Creating a settings menu" documents and the code did not use.

## The mock encoded the same mistake

`tests/mock_wow_api.lua` had `RegisterVerticalLayoutCategory` return one value, so a discarded initializer looked exactly like a used one and **no test could have caught this**. It returns a layout now, recording the initializers it is given, and the section-header helper exists as the global it is.

## Verified

| injection | what reddens |
|---|---|
| the initializer built and discarded again | the section-header test — nothing reaches the layout |
| the layout not captured from the second return value | the same test, on the capture assertion |

## After the rebase onto main

[#48](https://github.com/CybotTM/wow-quickroute/pull/48) had meanwhile put the header element into the same function through `SettingsPanel:GetLayout(category)`; the rebase left two `layout` locals and the section header went to the second one. Both now go to the layout `RegisterVerticalLayoutCategory` returns, with `GetLayout` as the fallback when the category brings none, and the test double hands out one layout for both lookups as the client does (1e07c99).

The header element is also added only when `C_XMLUtil.GetTemplateInfo` knows its template (8981407). The settings list asks for the extent while laying out, and an unknown template is an error that takes the whole page down; that happened in game with an install whose TOC lacked `SettingsHeader.xml`. Test seen to fail with the guard removed.

13804 Lua assertions, 0 failures.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_

