### PR TITLE
fix(data): add the zone crossings the survey walked on 2026-09-01

### DIFF
--- a/QuickRoute/Data/ZoneAdjacency.lua
+++ b/QuickRoute/Data/ZoneAdjacency.lua
@@ -96,6 +96,7 @@ QR.Continents = {
             77,   -- Felwood
             80,   -- Moonglade
             81,   -- Silithus
+            327,  -- Ahn'Qiraj: The Fallen Kingdom (walked from Uldum and into Silithus, survey 2026-09-01)
             83,   -- Winterspring
             106,  -- Bloodmyst Isle
             199,  -- Southern Barrens
@@ -311,6 +312,7 @@ QR.ZoneToContinent[876]  = "KUL_TIRAS"           -- Kul Tiras (continent, mapID 
 QR.ZoneToContinent[1550] = "SHADOWLANDS"       -- Shadowlands (continent)
 QR.ZoneToContinent[1978] = "DRAGON_ISLES"      -- Dragon Isles (continent)
 QR.ZoneToContinent[2274] = "KHAZ_ALGAR"        -- Khaz Algar (continent)
+QR.ZoneToContinent[2537] = "EASTERN_KINGDOMS"  -- Quel'Thalas (Midnight continent map, type 2, parent 13; its zones are listed under Eastern Kingdoms)
 
 -------------------------------------------------------------------------------
 -- Continent Key → Map ID (for C_Map.GetMapInfo localization)
@@ -869,6 +871,7 @@ QR.ZoneAdjacencies = {
     [69] = {  -- Feralas
         {zone = 66, travelTime = 90},    -- Desolace
         {zone = 64, travelTime = 60},    -- Thousand Needles
+        {zone = 81, travelTime = 90},    -- Silithus (crossing walked 2026-09-01, zone survey)
     },
     [64] = {  -- Thousand Needles
         {zone = 199, travelTime = 60},   -- Southern Barrens
@@ -892,6 +895,15 @@ QR.ZoneAdjacencies = {
     },
     [81] = {  -- Silithus
         {zone = 78, travelTime = 60},   -- Un'Goro Crater
+        {zone = 69, travelTime = 90},   -- Feralas (crossing walked 2026-09-01, zone survey)
+        {zone = 327, travelTime = 60},  -- Ahn'Qiraj: The Fallen Kingdom (crossing walked 2026-09-01, zone survey)
+    },
+    [327] = {  -- Ahn'Qiraj: The Fallen Kingdom (uiMapID 327, type 6, parent Kalimdor)
+        -- Both crossings recorded by the zone survey on 2026-09-01: entered
+        -- from Uldum 1527 on foot, left into Silithus 81 on foot. Times are
+        -- the file's usual estimates, not measured.
+        {zone = 81, travelTime = 60},   -- Silithus
+        {zone = 1527, travelTime = 60}, -- Uldum (N'Zoth Assault version)
     },
     [106] = {  -- Bloodmyst Isle (uiMapID 106, NOT Felwood)
         -- Accessed via Exodar/continent routing; no direct zone adjacency needed
@@ -913,6 +925,7 @@ QR.ZoneAdjacencies = {
     [1527] = {  -- Uldum (N'Zoth Assault version, same physical zone)
         {zone = 71, travelTime = 90},    -- Tanaris
         {zone = 249, travelTime = 0.001},-- Uldum (parent zone map)
+        {zone = 327, travelTime = 60},   -- Ahn'Qiraj: The Fallen Kingdom (crossing walked 2026-09-01, zone survey)
     },
     [204] = {  -- Vashj'ir / Abyssal Depths (boat from Stormwind/Orgrimmar)
         -- Accessed via boat from Eastern Kingdoms (see StandalonePortals)

--- a/tests/test_zoneadjacency.lua
+++ b/tests/test_zoneadjacency.lua
@@ -775,3 +775,35 @@ T:run("ZoneAdjacencies: no zone lists a neighbour more than once", function(t)
     t:assertEqual(0, #offenders,
         "no duplicate neighbours (" .. table.concat(offenders, ", ") .. ")")
 end)
+
+-------------------------------------------------------------------------------
+-- Zone survey 2026-09-01: crossings the client recorded on foot
+-------------------------------------------------------------------------------
+
+local function hasNeighbour(t, fromZone, toZone)
+    local adj = QR.ZoneAdjacencies[fromZone]
+    t:assertNotNil(adj, "zone " .. fromZone .. " has an adjacency block")
+    if not adj then return false end
+    for _, entry in ipairs(adj) do
+        if entry.zone == toZone then return true end
+    end
+    return false
+end
+
+T:run("Survey: Ahn'Qiraj: The Fallen Kingdom (327) is a Kalimdor zone with walked crossings", function(t)
+    t:assertEqual(QR.ZoneToContinent[327], "KALIMDOR", "327 belongs to Kalimdor")
+    t:assertTrue(hasNeighbour(t, 327, 81), "327 -> 81 Silithus (walked)")
+    t:assertTrue(hasNeighbour(t, 81, 327), "81 -> 327 back")
+    t:assertTrue(hasNeighbour(t, 327, 1527), "327 -> 1527 Uldum (walked in from there)")
+    t:assertTrue(hasNeighbour(t, 1527, 327), "1527 -> 327 back")
+end)
+
+T:run("Survey: Silithus and Feralas are walkable neighbours", function(t)
+    t:assertTrue(hasNeighbour(t, 81, 69), "81 Silithus -> 69 Feralas (walked)")
+    t:assertTrue(hasNeighbour(t, 69, 81), "69 Feralas -> 81 Silithus back")
+end)
+
+T:run("Survey: the Quel'Thalas continent map resolves to Eastern Kingdoms", function(t)
+    t:assertEqual(QR.ZoneToContinent[2537], "EASTERN_KINGDOMS",
+        "2537 (Quel'Thalas, type 2, parent 13) falls back like the other continent maps")
+end)


### PR DESCRIPTION
## Summary

The zone survey recorded on 2026-09-01 (`QuickRouteDB.zoneSurvey`, 12 Kalimdor maps, 8 on-foot crossings) shows three crossings the adjacency table did not know, all with `walked = 1, loaded = 0`: Uldum 1527 → Ahn'Qiraj: The Fallen Kingdom 327, 327 → Silithus 81, and Silithus 81 → Feralas 69.

Map 327 was not in the graph at all — not in the Kalimdor zone list, no adjacency block — yet the client places the player on it (UiMap type 6, parent Kalimdor). It is now a Kalimdor zone with edges to Silithus and to Uldum 1527, which reaches the Cataclysm Uldum 249 over the existing 0.001s pair. Silithus and Feralas get the edge the walk proved. Travel times are the file's usual 60/90 estimates, not measured; each edge's comment names the crossing it comes from.

The Quel'Thalas continent map 2537 (type 2, parent 13) joins the continent-level fallback next to the other continent maps a user waypoint can land on; its zones already sit in the Eastern Kingdoms list.

The `/qrverify` report embedded in the same SavedVariables (addon v1.10.1) was checked row by row against `main`: Silvermoon 2393, Darnassus/Undercity removal, Zen Pilgrimage to 379, Tol Barad 244, the Ashran and class spell IDs, the non-existent 1584 and the Z table names are already fixed there. Windrunner Spire (1299) keeps its flagged coordinates — the survey carries no replacement. The five surveyed zones with `graphNodes = 0` (Ashenvale, Ahn'Qiraj, Winterspring, Azshara, Stonetalon) are not a data gap: flight points are not graph nodes by design, and those zones have no teleport destination.

## Type

- [x] Bug fix
- [ ] New feature
- [x] New teleport / portal data
- [ ] Localization
- [ ] Refactoring
- [ ] CI / build

## Testing

- [x] All tests pass (`lua5.1 tests/run_tests.lua`) — 13750 passed in both orders, 13700 on main; luacheck clean
- [ ] Tested in-game (if UI/gameplay change) — data only; the crossings themselves are the in-game evidence
- [x] New tests added (if applicable) — three survey tests; removing the 327 block and the Feralas edge fails six assertions (the existing symmetry test catches the reverse direction)

## Checklist

- [x] No Lua 5.2+ features (goto, bitwise, //)
- [x] Uses `QR.Colors`, `QR.L`, `QR.PlayerInfo` (no hardcoded values) — n/a, data tables only
- [x] Tooltips use `QR.AddTooltipBranding()` + `GameTooltip_Hide()` — n/a
- [x] Click handlers include `PlaySound(SOUNDKIT.*)` — n/a

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
