### PR TITLE
feat: the settings page opens with the designed header

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,6 +6,7 @@ std = "lua51"
 
 -- WoW global variables (read-write)
 globals = {
+    "QuickRouteSettingsHeaderMixin",
     -- Addon namespace
     "QR",
 
@@ -166,6 +167,9 @@ globals = {
 
 -- Read-only globals
 read_globals = {
+    "CreateColor",
+    "STANDARD_TEXT_FONT",
+    "SettingsPanel",
     "print",
     "pairs",
     "ipairs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- The settings page opens with the header from the design ("C2"): the logo, the addon's name, a subtitle and a line with version, author and site, drawn over a travel network with one route in gold; below it a status bar that says whether TomTom was found (and which version), how many teleports the character has, and a button that opens the route window. The settings themselves are unchanged, and Blizzard's own Defaults button stays where it is.
+- The settings page opens with the header from the design ("C2"): the logo, the addon's name, a subtitle, a line with version and author and the site below it, drawn over a travel network with one route in gold; below it a status bar that says whether TomTom was found (and which version), how many teleports the character has, and a button that opens the route window. The settings themselves are unchanged, and Blizzard's own Defaults button stays where it is.
 
 ### Fixed
 - The Kirin Tor Beacon, the Sunreaver Beacon and the Mobile Telemancy Beacon no longer count as ready everywhere. The game accepts the first two only on Isle of Thunder and in the Throne of Thunder, the third only in Suramar; away from there they read NOT HERE in the teleport inventory, the "usable" filter hides them, and the quick-teleport list and the map sidebar leave them out. The data carries the maps as `usableOnMaps`, next to the free-text `restriction` that was already there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- The settings page opens with the header from the design ("C2"): the logo, the addon's name, a subtitle and a line with version, author and site, drawn over a travel network with one route in gold; below it a status bar that says whether TomTom was found (and which version), how many teleports the character has, and a button that opens the route window. The settings themselves are unchanged, and Blizzard's own Defaults button stays where it is.
+
 ### Fixed
 - The Kirin Tor Beacon, the Sunreaver Beacon and the Mobile Telemancy Beacon no longer count as ready everywhere. The game accepts the first two only on Isle of Thunder and in the Throne of Thunder, the third only in Suramar; away from there they read NOT HERE in the teleport inventory, the "usable" filter hides them, and the quick-teleport list and the map sidebar leave them out. The data carries the maps as `usableOnMaps`, next to the free-text `restriction` that was already there.
 - The map sidebar's rows show their names and destinations again, and so do the list rows of the teleport inventory. Each text was set and then cleared by a `SetTextToFit()` call without a text, which the client reads as an empty string. The test double had made that call a no-op, which is why no test saw it; it now behaves like the client.

--- a/QuickRoute/Localization.lua
+++ b/QuickRoute/Localization.lua
@@ -306,6 +306,14 @@ L["SETTINGS_COMMANDS_HINT"] = "/qr - Route window | /qrteleports - Inventory | /
 -- Icon buttons
 L["SETTINGS_ICON_BUTTONS"] = "Use Icon Buttons"
 L["SETTINGS_ICON_BUTTONS_TT"] = "Replace text labels on buttons with icons for a more compact UI"
+L["SETTINGS_HEADER_SUBTITLE"] = "Shortest way to your destination, via teleports, portals and spells."
+L["SETTINGS_VERSION"] = "Version"
+L["SETTINGS_TOMTOM"] = "TomTom"
+L["SETTINGS_TOMTOM_FOUND"] = "found"
+L["SETTINGS_TOMTOM_FOUND_VERSION"] = "found, v%s"
+L["SETTINGS_TOMTOM_MISSING"] = "not found"
+L["SETTINGS_TELEPORTS_FOUND"] = "Teleports found"
+L["SETTINGS_OPEN_ROUTE"] = "Open route window"
 
 -- Map teleport button
 L["MAP_BTN_LEFT_CLICK"] = "Left-click: Use teleport"
@@ -620,6 +628,14 @@ if GetLocale() == "deDE" then
     -- Icon buttons
     L["SETTINGS_ICON_BUTTONS"] = "Symbol-Buttons verwenden"
     L["SETTINGS_ICON_BUTTONS_TT"] = "Textbeschriftungen auf Buttons durch Symbole ersetzen für eine kompaktere Oberfläche"
+    L["SETTINGS_HEADER_SUBTITLE"] = "Kürzester Weg zum Ziel, über Teleports, Portale und Zauber."
+    L["SETTINGS_VERSION"] = "Version"
+    L["SETTINGS_TOMTOM"] = "TomTom"
+    L["SETTINGS_TOMTOM_FOUND"] = "erkannt"
+    L["SETTINGS_TOMTOM_FOUND_VERSION"] = "erkannt, v%s"
+    L["SETTINGS_TOMTOM_MISSING"] = "nicht gefunden"
+    L["SETTINGS_TELEPORTS_FOUND"] = "Teleports erkannt"
+    L["SETTINGS_OPEN_ROUTE"] = "Routenfenster öffnen"
 
     -- Map teleport button
     L["MAP_BTN_LEFT_CLICK"] = "Linksklick: Teleport verwenden"

--- a/QuickRoute/Modules/SettingsHeader.lua
+++ b/QuickRoute/Modules/SettingsHeader.lua
@@ -1,7 +1,7 @@
 -- SettingsHeader.lua
 -- The header element of the settings page: "C2 — Leyliniennetz" from the
 -- design canvas. A 236px band with the logo (112px), the addon name, a
--- subtitle and a meta line (version, author, site), drawn over a travel
+-- subtitle, a line with version and author, and the site, drawn over a travel
 -- network -- nodes, edges and one route in gold -- and, below that, a status
 -- bar with the TomTom detection, the number of teleports found and a button
 -- that opens the route window. The settings themselves follow unchanged;

--- a/QuickRoute/Modules/SettingsHeader.lua
+++ b/QuickRoute/Modules/SettingsHeader.lua
@@ -192,6 +192,13 @@ function QuickRouteSettingsHeaderMixin:OnLoad()
     metaLine:SetPoint("RIGHT", self, "RIGHT", -PAD_X, 0)
     self.MetaLine = metaLine
 
+    -- The site gets its own line: next to version and author it does not fit
+    -- the width the settings list leaves right of the logo.
+    local siteLine = Text(self, "GameFontNormalSmall", 13, CYAN[1], CYAN[2], CYAN[3])
+    siteLine:SetPoint("TOPLEFT", metaLine, "BOTTOMLEFT", 0, -4)
+    siteLine:SetPoint("RIGHT", self, "RIGHT", -PAD_X, 0)
+    self.SiteLine = siteLine
+
     -- Status bar.
     local bar = CreateFrame("Frame", nil, self, "BackdropTemplate")
     bar:SetHeight(STATUS_BAR_HEIGHT)
@@ -253,8 +260,9 @@ end
 function QuickRouteSettingsHeaderMixin:Refresh()
     L = QR.L
     local data = SettingsHeader:GetStatusData()
-    self.MetaLine:SetText(string_format("%s %s  |cFF7D641C·|r  %s  |cFF7D641C·|r  |cFF4FD8EE%s|r",
-        L["SETTINGS_VERSION"] or "Version", data.version, data.author, data.site))
+    self.MetaLine:SetText(string_format("%s %s  |cFF7D641C·|r  %s",
+        L["SETTINGS_VERSION"] or "Version", data.version, data.author))
+    self.SiteLine:SetText(data.site)
     self.TomTomText:SetText(SettingsHeader:FormatTomTom(data))
     if data.tomtomFound then
         self.TomTomDot:SetVertexColor(CYAN[1], CYAN[2], CYAN[3], 1)

--- a/QuickRoute/Modules/SettingsHeader.lua
+++ b/QuickRoute/Modules/SettingsHeader.lua
@@ -1,0 +1,265 @@
+-- SettingsHeader.lua
+-- The header element of the settings page: "C2 — Leyliniennetz" from the
+-- design canvas. A 236px band with the logo (112px), the addon name, a
+-- subtitle and a meta line (version, author, site), drawn over a travel
+-- network -- nodes, edges and one route in gold -- and, below that, a status
+-- bar with the TomTom detection, the number of teleports found and a button
+-- that opens the route window. The settings themselves follow unchanged;
+-- Blizzard's own "Defaults" button stays where it is.
+local ADDON_NAME, QR = ...
+
+local CreateFrame = CreateFrame
+local CreateColor = CreateColor
+local string_format = string.format
+
+QR.SettingsHeader = {}
+local SettingsHeader = QR.SettingsHeader
+
+local L
+
+-- Design tokens, from the canvas.
+local HEADER_HEIGHT = 236
+local PAD_X = 34
+local PAD_TOP = 26
+local LOGO_SIZE = 112
+local TITLE_GAP = 22
+local STATUS_BAR_HEIGHT = 50
+local GOLD = { 1.0, 0.82, 0.0 }            -- #ffd100
+local GOLD_DIM = { 0.788, 0.647, 0.18 }    -- #c9a52e
+local PARCH = { 0.937, 0.886, 0.769 }      -- #efe2c4
+local GRAY = { 0.616, 0.616, 0.616 }       -- #9d9d9d
+local CYAN = { 0.31, 0.847, 0.933 }        -- #4fd8ee
+local ROUND_DOT = "Interface\\COMMON\\Indicator-Gray"
+local WHITE = "Interface\\Buttons\\WHITE8x8"
+local SITE_URL = "github.com/CybotTM/wow-quickroute"
+
+-- The network, in the 820x236 space the design was drawn in. Edges are pairs
+-- of node coordinates; the route is the gold path through five of them.
+local NET_EDGES = {
+    { 92, 178, 212, 214 }, { 212, 214, 344, 196 }, { 344, 196, 286, 128 }, { 286, 128, 92, 178 },
+    { 286, 128, 430, 150 }, { 430, 150, 520, 214 }, { 520, 214, 648, 190 }, { 648, 190, 742, 132 },
+    { 742, 132, 636, 78 }, { 636, 78, 508, 96 }, { 508, 96, 430, 150 }, { 508, 96, 396, 44 },
+    { 396, 44, 286, 128 }, { 396, 44, 214, 60 }, { 214, 60, 92, 178 }, { 742, 132, 790, 202 },
+    { 648, 190, 560, 152 }, { 560, 152, 508, 96 },
+}
+local NET_NODES = {
+    { 212, 214 }, { 344, 196 }, { 430, 150 }, { 520, 214 }, { 648, 190 },
+    { 508, 96 }, { 214, 60 }, { 560, 152 }, { 790, 202 },
+}
+local ROUTE = { { 92, 178 }, { 286, 128 }, { 396, 44 }, { 636, 78 }, { 742, 132 } }
+
+-------------------------------------------------------------------------------
+-- Data (no frames, so tests can read it)
+-------------------------------------------------------------------------------
+
+--- What the status bar and the meta line show.
+-- @return table { version, author, site, tomtomFound, tomtomVersion, teleportCount }
+function SettingsHeader:GetStatusData()
+    local meta = C_AddOns and C_AddOns.GetAddOnMetadata
+    local version = QR.version or (meta and meta(ADDON_NAME, "Version")) or "dev"
+    local author = (meta and meta(ADDON_NAME, "Author")) or "Sebastian Mendel"
+    local tomtomFound = QR.WaypointIntegration and QR.WaypointIntegration:HasTomTom() or false
+    local tomtomVersion = tomtomFound and meta and meta("TomTom", "Version") or nil
+    local count = QR.PlayerInventory and QR.PlayerInventory:GetTeleportCount() or 0
+    return {
+        version = version,
+        author = author,
+        site = SITE_URL,
+        tomtomFound = tomtomFound,
+        tomtomVersion = tomtomVersion,
+        teleportCount = count,
+    }
+end
+
+--- The TomTom line of the status bar.
+function SettingsHeader:FormatTomTom(data)
+    L = L or QR.L
+    if data.tomtomFound then
+        if data.tomtomVersion and data.tomtomVersion ~= "" then
+            return string_format(L["SETTINGS_TOMTOM_FOUND_VERSION"] or "found, v%s", data.tomtomVersion)
+        end
+        return L["SETTINGS_TOMTOM_FOUND"] or "found"
+    end
+    return L["SETTINGS_TOMTOM_MISSING"] or "not found"
+end
+
+-------------------------------------------------------------------------------
+-- Drawing helpers
+-------------------------------------------------------------------------------
+
+local function Line(parent, x1, y1, x2, y2, r, g, b, a, thickness, layer, sublevel)
+    local line = parent:CreateLine(nil, layer or "ARTWORK", nil, sublevel or 0)
+    line:SetColorTexture(r, g, b, a)
+    line:SetThickness(thickness)
+    line:SetStartPoint("TOPLEFT", parent, x1, -y1)
+    line:SetEndPoint("TOPLEFT", parent, x2, -y2)
+    return line
+end
+
+local function Dot(parent, x, y, size, r, g, b, a, layer, sublevel)
+    local dot = parent:CreateTexture(nil, layer or "ARTWORK", nil, sublevel or 0)
+    dot:SetTexture(ROUND_DOT)
+    dot:SetVertexColor(r, g, b, a)
+    dot:SetSize(size, size)
+    dot:SetPoint("CENTER", parent, "TOPLEFT", x, -y)
+    return dot
+end
+
+local function Text(parent, template, size, r, g, b)
+    local fs = parent:CreateFontString(nil, "OVERLAY", template)
+    if size then fs:SetFont(STANDARD_TEXT_FONT, size, "") end
+    if r then fs:SetTextColor(r, g, b) end
+    fs:SetShadowOffset(0, -1)
+    fs:SetShadowColor(0, 0, 0, 0.9)
+    fs:SetJustifyH("LEFT")
+    fs:SetWordWrap(false)
+    return fs
+end
+
+-------------------------------------------------------------------------------
+-- The element
+-------------------------------------------------------------------------------
+QuickRouteSettingsHeaderMixin = {}
+
+function QuickRouteSettingsHeaderMixin:OnLoad()
+    L = QR.L
+    self:SetHeight(HEADER_HEIGHT)
+
+    -- Night-blue ground, darkening to the right, and a hairline in gold below.
+    local bg = self:CreateTexture(nil, "BACKGROUND")
+    bg:SetAllPoints()
+    bg:SetColorTexture(1, 1, 1, 1)
+    bg:SetGradient("HORIZONTAL", CreateColor(0.086, 0.141, 0.29, 1), CreateColor(0.02, 0.027, 0.06, 1))
+    local rule = self:CreateTexture(nil, "BORDER")
+    rule:SetPoint("BOTTOMLEFT")
+    rule:SetPoint("BOTTOMRIGHT")
+    rule:SetHeight(1)
+    rule:SetColorTexture(GOLD[1], GOLD[2], GOLD[3], 0.34)
+
+    -- The travel network: faint cyan edges and nodes, one route in gold with a
+    -- soft glow (a wider, fainter line underneath).
+    for _, e in ipairs(NET_EDGES) do
+        Line(self, e[1], e[2], e[3], e[4], CYAN[1], CYAN[2], CYAN[3], 0.16, 1, "ARTWORK", 0)
+    end
+    for i = 1, #ROUTE - 1 do
+        local a, b = ROUTE[i], ROUTE[i + 1]
+        Line(self, a[1], a[2], b[1], b[2], GOLD[1], GOLD[2], GOLD[3], 0.12, 8, "ARTWORK", 1)
+        Line(self, a[1], a[2], b[1], b[2], GOLD[1], GOLD[2], GOLD[3], 0.72, 2.4, "ARTWORK", 2)
+    end
+    for _, n in ipairs(NET_NODES) do
+        Dot(self, n[1], n[2], 7, CYAN[1], CYAN[2], CYAN[3], 0.55, "ARTWORK", 3)
+    end
+    for i, n in ipairs(ROUTE) do
+        local isEnd = i == 1 or i == #ROUTE
+        if isEnd then
+            Dot(self, n[1], n[2], 25, GOLD[1], GOLD[2], GOLD[3], 0.30, "ARTWORK", 3)
+            Dot(self, n[1], n[2], 12, GOLD[1], GOLD[2], GOLD[3], 0.9, "ARTWORK", 4)
+        else
+            Dot(self, n[1], n[2], 9, 0.56, 0.914, 0.969, 0.9, "ARTWORK", 4)
+        end
+    end
+
+    -- Readability veil: strong on the left, where the text is.
+    local veil = self:CreateTexture(nil, "ARTWORK", nil, 5)
+    veil:SetAllPoints()
+    veil:SetColorTexture(1, 1, 1, 1)
+    veil:SetGradient("HORIZONTAL", CreateColor(0.02, 0.027, 0.06, 0.80), CreateColor(0.02, 0.027, 0.06, 0.44))
+
+    -- Logo, name, subtitle, meta line.
+    local logo = self:CreateTexture(nil, "OVERLAY")
+    logo:SetSize(LOGO_SIZE, LOGO_SIZE)
+    logo:SetPoint("TOPLEFT", self, "TOPLEFT", PAD_X, -PAD_TOP)
+    logo:SetTexture(QR.LOGO_PATH or "Interface\\Icons\\INV_Misc_Map02")
+    self.Logo = logo
+
+    local title = self:CreateFontString(nil, "OVERLAY", "GameFontNormalHuge")
+    title:SetFont("Fonts\\MORPHEUS.TTF", 34, "")
+    title:SetTextColor(GOLD[1], GOLD[2], GOLD[3])
+    title:SetShadowOffset(0, -2)
+    title:SetShadowColor(0, 0, 0, 0.9)
+    title:SetPoint("TOPLEFT", logo, "TOPRIGHT", TITLE_GAP, -8)
+    title:SetText(L["ADDON_TITLE"] or "QuickRoute")
+    self.Title = title
+
+    local subtitle = Text(self, "GameFontNormal", 14, PARCH[1], PARCH[2], PARCH[3])
+    subtitle:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -6)
+    subtitle:SetPoint("RIGHT", self, "RIGHT", -PAD_X, 0)
+    subtitle:SetText(L["SETTINGS_HEADER_SUBTITLE"] or "Shortest way to your destination, via teleports, portals and spells.")
+    self.Subtitle = subtitle
+
+    local metaLine = Text(self, "GameFontNormalSmall", 13, GOLD_DIM[1], GOLD_DIM[2], GOLD_DIM[3])
+    metaLine:SetPoint("TOPLEFT", subtitle, "BOTTOMLEFT", 0, -8)
+    metaLine:SetPoint("RIGHT", self, "RIGHT", -PAD_X, 0)
+    self.MetaLine = metaLine
+
+    -- Status bar.
+    local bar = CreateFrame("Frame", nil, self, "BackdropTemplate")
+    bar:SetHeight(STATUS_BAR_HEIGHT)
+    bar:SetPoint("TOPLEFT", logo, "BOTTOMLEFT", 0, -14)
+    bar:SetPoint("RIGHT", self, "RIGHT", -PAD_X, 0)
+    bar:SetBackdrop({ bgFile = WHITE, edgeFile = WHITE, edgeSize = 1 })
+    bar:SetBackdropColor(0.024, 0.035, 0.07, 0.78)
+    bar:SetBackdropBorderColor(GOLD[1], GOLD[2], GOLD[3], 0.20)
+    self.StatusBar = bar
+
+    local tomtomDot = bar:CreateTexture(nil, "ARTWORK")
+    tomtomDot:SetTexture(ROUND_DOT)
+    tomtomDot:SetSize(9, 9)
+    tomtomDot:SetPoint("LEFT", bar, "LEFT", 16, 0)
+    self.TomTomDot = tomtomDot
+
+    local tomtomLabel = Text(bar, "GameFontNormalSmall", 13, GRAY[1], GRAY[2], GRAY[3])
+    tomtomLabel:SetPoint("LEFT", tomtomDot, "RIGHT", 9, 0)
+    tomtomLabel:SetText(L["SETTINGS_TOMTOM"] or "TomTom")
+    local tomtomText = Text(bar, "GameFontNormalSmall", 13, PARCH[1], PARCH[2], PARCH[3])
+    tomtomText:SetPoint("LEFT", tomtomLabel, "RIGHT", 6, 0)
+    self.TomTomText = tomtomText
+
+    local sep = bar:CreateTexture(nil, "ARTWORK")
+    sep:SetWidth(1)
+    sep:SetPoint("TOP", bar, "TOP", 0, -11)
+    sep:SetPoint("BOTTOM", bar, "BOTTOM", 0, 11)
+    sep:SetPoint("LEFT", tomtomText, "RIGHT", 26, 0)
+    sep:SetColorTexture(GOLD[1], GOLD[2], GOLD[3], 0.16)
+
+    local countDot = bar:CreateTexture(nil, "ARTWORK")
+    countDot:SetTexture("Interface\\COMMON\\Indicator-Yellow")
+    countDot:SetSize(12, 12)
+    countDot:SetPoint("LEFT", sep, "RIGHT", 26, 0)
+    local countLabel = Text(bar, "GameFontNormalSmall", 13, GRAY[1], GRAY[2], GRAY[3])
+    countLabel:SetPoint("LEFT", countDot, "RIGHT", 9, 0)
+    countLabel:SetText(L["SETTINGS_TELEPORTS_FOUND"] or "Teleports found")
+    local countText = Text(bar, "GameFontNormalSmall", 13, PARCH[1], PARCH[2], PARCH[3])
+    countText:SetPoint("LEFT", countLabel, "RIGHT", 6, 0)
+    self.CountText = countText
+
+    local label = (L["SETTINGS_OPEN_ROUTE"] or "Open route window") .. "  |cFFC9A52E/qr|r"
+    local button = QR.CreateModernButton(bar, 12 + 7 * #label, 28)
+    button:SetPoint("RIGHT", bar, "RIGHT", -16, 0)
+    button:SetText(label)
+    if button.GetTextWidth then button:SetWidth(button:GetTextWidth() + 28) end
+    button:SetScript("OnClick", function()
+        if QR.MainFrame then QR.MainFrame:Show("route") end
+    end)
+    self.RouteButton = button
+end
+
+--- Called by the settings list whenever the element is shown.
+function QuickRouteSettingsHeaderMixin:Init(initializer)
+    self:Refresh()
+end
+
+--- Fill the live parts: version line, TomTom, teleport count.
+function QuickRouteSettingsHeaderMixin:Refresh()
+    L = QR.L
+    local data = SettingsHeader:GetStatusData()
+    self.MetaLine:SetText(string_format("%s %s  |cFF7D641C·|r  %s  |cFF7D641C·|r  |cFF4FD8EE%s|r",
+        L["SETTINGS_VERSION"] or "Version", data.version, data.author, data.site))
+    self.TomTomText:SetText(SettingsHeader:FormatTomTom(data))
+    if data.tomtomFound then
+        self.TomTomDot:SetVertexColor(CYAN[1], CYAN[2], CYAN[3], 1)
+    else
+        self.TomTomDot:SetVertexColor(GRAY[1], GRAY[2], GRAY[3], 1)
+    end
+    self.CountText:SetText(tostring(data.teleportCount))
+end

--- a/QuickRoute/Modules/SettingsHeader.xml
+++ b/QuickRoute/Modules/SettingsHeader.xml
@@ -1,0 +1,12 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/">
+	<!-- The header of the settings page, designed as "C2 — Leyliniennetz":
+	     logo, name, subtitle and meta line over a travel network, with a
+	     status bar below. Everything is drawn in SettingsHeader.lua; the
+	     template only fixes the element's height for the settings list. -->
+	<Frame name="QuickRouteSettingsHeaderTemplate" mixin="QuickRouteSettingsHeaderMixin" virtual="true">
+		<Size y="236"/>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Frame>
+</Ui>

--- a/QuickRoute/Modules/SettingsPanel.lua
+++ b/QuickRoute/Modules/SettingsPanel.lua
@@ -101,6 +101,15 @@ local function RegisterNativeSettings()
         L["ADDON_TITLE"] or "QuickRoute"
     )
 
+    -- The header element ("C2" on the design canvas) comes first; the global
+    -- SettingsPanel is Blizzard's frame, not this module.
+    local layout = _G.SettingsPanel and _G.SettingsPanel.GetLayout
+        and _G.SettingsPanel:GetLayout(category)
+    if layout then
+        SettingsPanel.headerInitializer = Settings.CreateElementInitializer("QuickRouteSettingsHeaderTemplate", {})
+        layout:AddInitializer(SettingsPanel.headerInitializer)
+    end
+
     -- General
     Settings.CreateElementInitializer("SettingsListSectionHeaderTemplate", { name = L["SETTINGS_GENERAL"] })
 

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -56,6 +56,8 @@ Modules\DungeonPicker.lua
 Modules\DestinationSearch.lua
 Modules\ServiceRouter.lua
 Modules\EncounterJournalButton.lua
+Modules\SettingsHeader.xml
+Modules\SettingsHeader.lua
 Modules\SettingsPanel.lua
 Modules\ZoneSurvey.lua
 Modules\Diagnostics.lua

--- a/tests/addon_loader.lua
+++ b/tests/addon_loader.lua
@@ -65,6 +65,7 @@ function AddonLoader:Load(MockWoW, options)
         "Modules/DestinationSearch.lua",
         "Modules/ServiceRouter.lua",
         "Modules/EncounterJournalButton.lua",
+        "Modules/SettingsHeader.lua",
         "Modules/SettingsPanel.lua",
         "Modules/ZoneSurvey.lua",
         "Modules/Diagnostics.lua",

--- a/tests/mock_wow_api.lua
+++ b/tests/mock_wow_api.lua
@@ -37,6 +37,7 @@ MockWoW.config = {
 
     -- Toys the player owns: { [itemID] = true }
     ownedToys = {},
+    addonMetadata = {},
 
     -- Spells the player knows: { [spellID] = true }
     knownSpells = {},
@@ -325,6 +326,9 @@ function MockWoW:Reset()
     self.config.inCombatLockdown = false
     self.config.bagItems = {}
     self.config.ownedToys = {}
+    self.config.addonMetadata = {}
+    _G.SettingsPanel._layouts = {}
+    _G.TomTom = nil
     self.config.knownSpells = {}
     self.config.uncachedSpells = {}
     self.config.uncachedItems = {}
@@ -384,7 +388,8 @@ local function CreateMockTexture(parent)
     function tex:SetShown(show) if show then self:Show() else self:Hide() end end
     function tex:IsShown() return self._shown end
     function tex:SetTexCoord() end
-    function tex:SetVertexColor() end
+    function tex:SetVertexColor(r, g, b, a) self._vertexColor = { r, g, b, a } end
+    function tex:SetGradient(orientation, minColor, maxColor) self._gradient = { orientation, minColor, maxColor } end
     function tex:SetAlpha(alpha) self._alpha = alpha end
     function tex:GetAlpha() return self._alpha end
     function tex:SetDesaturated(desat) self._desaturated = desat end
@@ -424,6 +429,8 @@ local function CreateMockFontString(parent)
     function fs:SetTextToFit(text) self._text = text or "" end
     function fs:SetFontObject() end
     function fs:SetFont() end
+    function fs:SetShadowOffset() end
+    function fs:SetShadowColor() end
     function fs:Show() self._shown = true end
     function fs:Hide() self._shown = false end
     function fs:IsShown() return self._shown end
@@ -627,6 +634,21 @@ local function CreateMockFrame(frameType, name, parent, template)
     end
 
     -- Texture and FontString creation
+    function frame:CreateLine(name, layer)
+        local line = {
+            _points = {},
+            SetColorTexture = function(self, r, g, b, a) self._color = { r, g, b, a } end,
+            SetThickness = function(self, thickness) self._thickness = thickness end,
+            SetStartPoint = function(self, point, rel, x, y) self._start = { point, rel, x, y } end,
+            SetEndPoint = function(self, point, rel, x, y) self._end = { point, rel, x, y } end,
+            Show = function(self) self._shown = true end,
+            Hide = function(self) self._shown = false end,
+        }
+        self._lines = self._lines or {}
+        self._lines[#self._lines + 1] = line
+        return line
+    end
+    function frame:GetTextWidth() return #(self._text or "") * 7 end
     function frame:CreateTexture(name, layer)
         return CreateMockTexture(self)
     end
@@ -1661,13 +1683,36 @@ function MockWoW:Install()
                 GetData = function() return items end,
             }
         end,
-        CreateElementInitializer = function(template, data) return {} end,
+        CreateElementInitializer = function(template, data) return { _template = template, _data = data } end,
         VarType = {
             Boolean = "boolean",
             Number = "number",
             String = "string",
         },
     }
+
+    _G.STANDARD_TEXT_FONT = "Fonts\\FRIZQT__.TTF"
+    _G.CreateColor = function(r, g, b, a) return { r = r, g = g, b = b, a = a, GetRGBA = function(self) return self.r, self.g, self.b, self.a end } end
+
+    -- Blizzard's settings panel frame: hands out one layout per category and
+    -- records what the addon adds to it, in order.
+    _G.SettingsPanel = {
+        _layouts = {},
+        GetLayout = function(self, category)
+            local layout = self._layouts[category]
+            if not layout then
+                layout = { _initializers = {}, AddInitializer = function(l, init) l._initializers[#l._initializers + 1] = init end }
+                self._layouts[category] = layout
+            end
+            return layout
+        end,
+    }
+
+    _G.C_AddOns = _G.C_AddOns or {}
+    _G.C_AddOns.GetAddOnMetadata = function(name, field)
+        local meta = cfg.addonMetadata and cfg.addonMetadata[name]
+        return meta and meta[field] or nil
+    end
 
     _G.MinimalSliderWithSteppersMixin = {
         Label = { Right = 1 },

--- a/tests/test_settingsheader.lua
+++ b/tests/test_settingsheader.lua
@@ -1,0 +1,81 @@
+-------------------------------------------------------------------------------
+-- test_settingsheader.lua
+-- The settings page header ("C2 — Leyliniennetz"): what it shows and where
+-- it sits in the settings list.
+-------------------------------------------------------------------------------
+
+local T, QR, MockWoW = ...
+
+local function resetState()
+    MockWoW:Reset()
+    QR.PlayerInventory.teleportItems = {}
+    QR.PlayerInventory.toys = {}
+    QR.PlayerInventory.spells = {}
+    QR.SettingsPanel.initialized = false
+    QR.SettingsPanel.category = nil
+    QR.SettingsPanel.headerInitializer = nil
+end
+
+local function makeHeader()
+    local frame = CreateFrame("Frame")
+    for k, v in pairs(QuickRouteSettingsHeaderMixin) do frame[k] = v end
+    frame:OnLoad()
+    return frame
+end
+
+T:run("SettingsHeader: the header element is the first thing in the layout", function(t)
+    resetState()
+    QR.SettingsPanel:Register()
+    local layout = _G.SettingsPanel:GetLayout(QR.SettingsPanel.category)
+    t:assertNotNil(layout._initializers[1], "something was added to the layout")
+    t:assertEqual("QuickRouteSettingsHeaderTemplate", layout._initializers[1]._template, "the header comes first")
+    t:assertEqual(QR.SettingsPanel.headerInitializer, layout._initializers[1])
+end)
+
+T:run("SettingsHeader: status data reads version, TomTom and the teleport count", function(t)
+    resetState()
+    MockWoW.config.addonMetadata.TomTom = { Version = "4.3.9" }
+    _G.TomTom = {}
+    QR.PlayerInventory.teleportItems = { [6948] = {}, [140192] = {} }
+    QR.PlayerInventory.toys = { [64488] = {} }
+
+    local data = QR.SettingsHeader:GetStatusData()
+    t:assertEqual(QR.version, data.version)
+    t:assertTrue(data.tomtomFound, "TomTom present")
+    t:assertEqual("4.3.9", data.tomtomVersion)
+    t:assertEqual(3, data.teleportCount)
+    t:assertEqual("found, v4.3.9", QR.SettingsHeader:FormatTomTom(data))
+    _G.TomTom = nil
+end)
+
+T:run("SettingsHeader: without TomTom the bar says so", function(t)
+    resetState()
+    local data = QR.SettingsHeader:GetStatusData()
+    t:assertFalse(data.tomtomFound)
+    t:assertEqual("not found", QR.SettingsHeader:FormatTomTom(data))
+    t:assertEqual(0, data.teleportCount)
+end)
+
+T:run("SettingsHeader: the element draws the network, the logo and the status bar", function(t)
+    resetState()
+    local header = makeHeader()
+    t:assertNotNil(header.Logo, "logo")
+    t:assertNotNil(header.Title, "title")
+    t:assertNotNil(header.StatusBar, "status bar")
+    t:assertNotNil(header.RouteButton, "route button")
+    t:assertTrue(#(header._lines or {}) >= 18 + 2 * 4, "edges and the route are drawn as lines")
+    t:assertEqual(236, header:GetHeight(), "the design's header height")
+end)
+
+T:run("SettingsHeader: Init fills the live values", function(t)
+    resetState()
+    _G.TomTom = {}
+    QR.PlayerInventory.toys = { [64488] = {}, [140192] = {} }
+    local header = makeHeader()
+    header:Init({})
+    t:assertEqual("2", header.CountText:GetText())
+    t:assertEqual("found", header.TomTomText:GetText())
+    t:assertNotNil(header.MetaLine:GetText():find(QR.version, 1, true), "version in the meta line")
+    t:assertNotNil(header.MetaLine:GetText():find("github.com/CybotTM/wow-quickroute", 1, true), "site in the meta line")
+    _G.TomTom = nil
+end)

--- a/tests/test_settingsheader.lua
+++ b/tests/test_settingsheader.lua
@@ -76,6 +76,6 @@ T:run("SettingsHeader: Init fills the live values", function(t)
     t:assertEqual("2", header.CountText:GetText())
     t:assertEqual("found", header.TomTomText:GetText())
     t:assertNotNil(header.MetaLine:GetText():find(QR.version, 1, true), "version in the meta line")
-    t:assertNotNil(header.MetaLine:GetText():find("github.com/CybotTM/wow-quickroute", 1, true), "site in the meta line")
+    t:assertNotNil(header.SiteLine:GetText():find("github.com/CybotTM/wow-quickroute", 1, true), "site on its own line")
     _G.TomTom = nil
 end)


### PR DESCRIPTION
Implements the chosen variant of the design canvas "QuickRoute Optionen-Header", **C2 — Leyliniennetz**. The settings page began with its first checkbox; the design puts a 236px header above the controls.

**What the header shows.** The logo at 112px; the addon's name in the client's serif face (Morpheus, 34px, gold), the subtitle ("Shortest way to your destination, via teleports, portals and spells."), a line with version and author, and the site below it in the link colour. The design has all three on one line; beside the logo that does not fit the width the settings list leaves, and the client would wrap it into the status bar, so the site got its own line (9e1fef6 after the rebase onto main). Below it a status bar: whether TomTom was found and which version, how many teleports the character has (from `PlayerInventory:GetTeleportCount`, the placeholder 43 of the mock is gone), and a button that opens the route window. The background is the travel network the design drew: faint cyan edges and nodes, one route in gold with a soft glow, a readability veil on the left where the text sits.

**How it is built.** The header is an element of Blizzard's settings list: `SettingsHeader.xml` fixes the 236px extent the list reads from the template, `QuickRouteSettingsHeaderMixin` draws everything in Lua (`CreateLine`, `SetGradient`, round indicator textures) and `Init` refreshes the live values through `QR.SettingsHeader:GetStatusData()`. `SettingsPanel:Register` adds the element to the layout before the controls. The settings themselves are unchanged. Blizzard's own Defaults button, which the mock also shows top-right, is not duplicated.

**Left out, on purpose.** The design has the network continue at 5% behind the settings rows. Those rows are Blizzard's own elements in a scrolled list; drawing under them from the header element is not worth the fight and is not built.

**Tests.** 13721 pass. New: the header is the first initializer in the layout; the status data reads version, TomTom and its version, and the teleport count; the element draws its lines, logo and bar at 236px; `Init` fills count, TomTom line, meta line and site line. Each verified by defect injection (not adding the initializer, answering "found" without TomTom, not filling the count). The test double gains `CreateLine`, `SetGradient`, `CreateColor`, `C_AddOns.GetAddOnMetadata` and Blizzard's `SettingsPanel:GetLayout`.

Rendered in the UI simulator against this branch; the render is in the PR conversation.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
