### PR TITLE
feat(ci): attest the build provenance of the release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
     needs: [tests, luacheck]
     permissions:
       contents: write
+      # Build provenance. The OIDC token is what identifies this workflow, this
+      # repository and this commit to the attestation store; without both of
+      # these the attest step cannot record anything.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -157,6 +162,17 @@ jobs:
           cd dist
           zip -r "QuickRoute-${VERSION}.zip" QuickRoute/
           echo "Created QuickRoute-${VERSION}.zip ($(du -h "QuickRoute-${VERSION}.zip" | cut -f1))"
+
+      # Before the upload, so the statement exists for the exact bytes that are
+      # published rather than for a rebuild of them. A downloader checks it with
+      #   gh attestation verify QuickRoute-<version>.zip --repo CybotTM/wow-quickroute
+      # which answers whether this workflow, at this commit, produced that file.
+      # CurseForge and Wago carry no attestation of their own, so this covers the
+      # GitHub download only.
+      - name: Attest the build provenance of the package
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/QuickRoute-${{ steps.version.outputs.version }}.zip
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
Closes [#55](https://github.com/CybotTM/wow-quickroute/issues/55).

The release job publishes `QuickRoute-<version>.zip` with nothing that ties it to this workflow, this repository or this commit. It now attests the package, and the statement covers the exact bytes that get uploaded: the step sits between packaging and the release upload, so it describes the file that is published rather than a rebuild of it.

A downloader checks it with:

```
gh attestation verify QuickRoute-1.17.0.zip --repo CybotTM/wow-quickroute
```

`id-token: write` and `attestations: write` are added to the release job because the OIDC token is what identifies the workflow to the attestation store; without both, the step records nothing. `contents: write` is unchanged.

## What this does not cover

CurseForge and Wago carry no attestation of their own, so this reaches the GitHub download and nothing else. That was the open question in the issue, and it is worth stating plainly rather than leaving implied: most people install this addon through the CurseForge app or WoWUp, and none of them will ever see this. The GitHub asset is the one path where the check is available, and the cost is one step in a job that already runs.

## Verification, and what is not verified

The pinned action was checked rather than assumed: `4d10147` exists in `actions/attest-build-provenance`, its commit date sits five minutes before the `v4.2.2` release, and `subject-path` is a real input of `action.yml` at that SHA. The workflow parses, and the release job's step order puts the attestation between `Package addon` and `Create GitHub release`.

Attestations need a public repository or Advanced Security, and a step that cannot record one fails the job it is in — which would have turned every future release red. This repository is public, so the precondition holds.

The step itself has not run. `release.yml` triggers on `v*` tags only, so the first execution is the next release — deliberately not worked around by adding `workflow_dispatch`, since that job holds `CF_API_KEY` and `WAGO_API_TOKEN` and a manual trigger is a bigger change than this fix. The check to run after the next tag is the `gh attestation verify` line above; if it fails, the fix is wrong and this needs reopening.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014LbhshbQ8jBjLU2ymEZHbr)_
