### PR TITLE
fix(routing): one faction rule for a character who has neither

### DIFF
--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -1296,8 +1296,14 @@ function PathCalculator:FlightPointFor(uiMapID)
     -- dropping it reddens nothing. It is kept because a false faction here
     -- silently filters the whole flight network.
     local faction = QR.PlayerInfo and QR.PlayerInfo:GetFaction()
+    -- A character who is neither Alliance nor Horde -- a pandaren who has not
+    -- chosen -- can use a neutral flight master and no other: the faction ones
+    -- are hostile to them. AddZoneNodes has always read it that way for zone
+    -- nodes; this returned every point instead, so one character got no
+    -- Stormwind node and every Alliance flight master. One rule now, in both
+    -- places, and it is the one the game plays by.
     if faction ~= "Alliance" and faction ~= "Horde" then
-        return point
+        return point.faction == "both" and point or nil
     end
     if point.faction == "both" or point.faction == faction then
         return point

--- a/tests/test_pathfinding.lua
+++ b/tests/test_pathfinding.lua
@@ -2425,15 +2425,26 @@ T:run("A settled faction is still cached", function(t)
     QR.PlayerInfo:InvalidateCache()
 end)
 
-T:run("A character of neither faction keeps the whole flight network", function(t)
-    -- UnitFactionGroup returns "Neutral" for a pandaren who has not picked a
-    -- side. The first version of the accessor tested `not faction`, which can
-    -- never be true -- GetFaction falls back to "Alliance" -- so a neutral
-    -- character matched no branch and silently lost 74 of 141 zones and 392 of
-    -- its 479 flight edges against the behaviour before the filter existed.
-    -- (479, not 599: a neutral character never had the faction capitals as
-    -- graph nodes, so fewer zones could carry a flight edge to begin with.)
+T:run("A character of neither faction gets the neutral flight masters, and only those", function(t)
+    -- Two things this pins, and they pull in opposite directions.
+    --
+    -- Not zero: UnitFactionGroup returns "Neutral" for a pandaren who has not
+    -- picked a side, and the first version of the accessor tested `not faction`,
+    -- which can never be true because GetFaction falls back to "Alliance". A
+    -- neutral character matched no branch and silently lost 74 of 141 zones and
+    -- 392 of its 479 flight edges.
+    --
+    -- Not all of them either: the fix for that returned every point unfiltered,
+    -- which contradicted AddZoneNodes, where the same character has never had a
+    -- faction capital as a graph node. In the game a faction flight master is
+    -- hostile to them, so AddZoneNodes is the rule that matches, and both
+    -- accessors read it the same way now.
     resetState()
+    local neutralOnly = 0
+    for _, point in pairs(QR.FlightPoints or {}) do
+        if point.faction == "both" then neutralOnly = neutralOnly + 1 end
+    end
+
     local usable = {}
     for _, faction in ipairs({ "Alliance", "Neutral" }) do
         MockWoW.config.playerFaction = faction
@@ -2447,11 +2458,14 @@ T:run("A character of neither faction keeps the whole flight network", function(
 
     local total = 0
     for _ in pairs(QR.FlightPoints or {}) do total = total + 1 end
-    t:assertEqual(total, usable.Neutral,
-        "a neutral character can use every zone (" .. tostring(usable.Neutral)
+
+    t:assertEqual(neutralOnly, usable.Neutral,
+        "a neutral character sees the neutral masters (" .. tostring(usable.Neutral)
             .. " of " .. total .. ")")
-    t:assertGreaterThan(usable.Neutral, usable.Alliance,
-        "which is strictly more than a faction sees, since nothing is filtered out")
+    t:assertGreaterThan(usable.Neutral, 0,
+        "and not none of them, which is what the `not faction` predicate did")
+    t:assertGreaterThan(total, usable.Neutral,
+        "and not all of them, which is what contradicted AddZoneNodes")
 
     MockWoW.config.playerFaction = "Alliance"
     QR.PlayerInfo:InvalidateCache()
@@ -2819,3 +2833,4 @@ T:run("AddZoneNodes: a neutral city is there for both sides", function(t)
     -- helper leaves the faction on Horde and a graph built for it.
     resetState()
 end)
+


### PR DESCRIPTION
Closes [#28](https://github.com/CybotTM/wow-quickroute/issues/28). The issue has two halves and they ended differently — one was already fixed, one is fixed here, and a third thing turned up that the issue got wrong.

## The overlapping boxes are already fixed

`Rebel Camp, Stranglethorn Vale` is in `FlightPoints.lua` today, under uiMap 224. The name-corroboration rule the issue proposed — prefer a box the node's own name states over the strictly smallest one — shipped with the flight-master work in [#38](https://github.com/CybotTM/wow-quickroute/pull/38), and `generate_flight_points.py` now carries it with the Rebel Camp case named in the comment.

It lands on 224 (`Stranglethorn Vale`) rather than 50 (`Northern Stranglethorn`) because that is what the node's own name says, and 224 is modelled in `ZoneAdjacency.lua` as the parent map covering 50 and 210. So the node is neither dropped nor stranded. Nothing to do; verified rather than assumed.

## The two faction rules now agree

`AddZoneNodes` keeps a node when its faction is `both` or the player's, so a pandaren who has not picked a side got no Stormwind and no Orgrimmar. `FlightPointFor` returned every point unfiltered for that same character, so they got every Alliance *and* Horde flight master. Both could not be right.

In the game a faction flight master is hostile to a neutral character, so `AddZoneNodes` is the rule that matches, and `FlightPointFor` now reads it the same way: the neutral masters and only those, **95 of 146** rather than all 146.

**This is not the change that caused the regression the loose rule was written to fix.** That one tested `not faction`, which can never be true because `GetFaction` falls back to `"Alliance"` — so a neutral character matched no branch and lost 74 of 141 zones. Measured here: `GetFaction()` returns `"Neutral"` for that character, and the new rule leaves them 95 zones, not zero.

The test that pinned the loose rule is rewritten to pin both ends rather than one: not none of them, which was that bug, and not all of them, which was the contradiction. Against the loose rule both new assertions fail. `lua tests/run_tests.lua`: 13908 passed, 0 failed.

## One thing the issue has wrong, and it is worth recording

The issue says `AddZoneNodes`' faction filter is uncovered — "replacing the condition with `true` leaves the whole suite green". That is true, and I tried to close it. The test does not work, because **the filter does not keep faction capitals out of a neutral character's graph in the first place**: with `GetFaction()` returning `"Neutral"`, `graph.nodes["Stormwind City"]` is still present, so something else adds the capital regardless of that filter.

That makes the filter not merely untested but partly ineffective, which is a different and larger finding than the issue describes. I have not chased which pass adds it — that is a separate change with its own blast radius, and guessing at it inside this one would be the worse move. Filed as a follow-up rather than left in a commit message: **[#57](https://github.com/CybotTM/wow-quickroute/issues/57)**.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014LbhshbQ8jBjLU2ymEZHbr)_
