### PR TITLE
chore: prepare QuickRoute 1.18.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.18.1] - 2026-09-07
+
 ### Fixed
 - Filled the native top and left gutters around the Settings header background while preserving the positions of its controls and settings list.
 - Sized grouped teleport cards to the actual scroll viewport so the last column and its status indicators are fully visible.
@@ -379,6 +381,7 @@
 - CI pipeline (luacheck + tests)
 - CurseForge + Wago automated publishing
 
-[Unreleased]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.0...HEAD
+[Unreleased]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.1...HEAD
+[1.18.1]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/CybotTM/wow-quickroute/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/CybotTM/wow-quickroute/compare/v1.16.0...v1.17.0

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Estimates fast routes to destinations using known teleports, portals and transports
 ## Author: Sebastian Mendel
-## Version: 1.18.0
+## Version: 1.18.1
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Prepare QuickRoute 1.18.1 for the UI fixes merged in #64: fill the Settings header gutters, keep the final teleport-card column visible, and avoid duplicate zone names. The release also includes the refreshed screenshot gallery and documented simulator corrections.

Updates the TOC version and CHANGELOG release section/comparison links. Validation: 16,028 Lua assertions pass in each file order, Luacheck has zero warnings/errors across 120 files, and all 47 Python tests pass. Runtime version metadata is read from the TOC; release tagging and publication follow after this PR's checks and merge.
