### PR TITLE
fix: stop re-routing every tracked quest each second, and go idle in combat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Stopped recalculating every tracked quest's route about once a second while moving, which stuttered the game and grew more expensive the more addons were installed. Routes are now reused until the player has actually moved a meaningful distance, changed zone, or changed which quests are tracked.
+- Left the game alone during combat. Routes, inventory scans and zone survey records are no longer computed mid-fight; the postponed work runs once the fight is over, except a zone crossing, which is dropped rather than recorded late against the wrong position.
+
 ## [1.18.1] - 2026-09-07
 
 ### Fixed

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -593,6 +593,50 @@ eventFrame:RegisterEvent("TOYS_UPDATED")
 eventFrame:RegisterEvent("SPELLS_CHANGED")
 eventFrame:RegisterEvent("SKILL_LINES_CHANGED")
 
+--- The scan the debounce timer runs. Also called from the leave-combat callback
+-- below, for the case where the timer landed mid-fight and postponed it.
+function PlayerInventory:RunDeferredScan()
+    PlayerInventory.pendingScan = false
+    PlayerInventory.scanDeferredByCombat = false
+    local force = forceGraphRefresh
+    forceGraphRefresh = false
+
+    -- Skip scan if addon not fully initialized yet
+    if not QR.db then return end
+
+    -- Perform the scan
+    local before = not force and PlayerInventory:GetAllTeleports()
+    PlayerInventory:ScanAll()
+    local changed = force or not SameTeleports(before, PlayerInventory:GetAllTeleports())
+
+    -- Notify PathCalculator if it exists (defer during combat to avoid expensive graph rebuild)
+    if changed and QR.PathCalculator and QR.PathCalculator.OnInventoryChanged then
+        if InCombatLockdown() then
+            QR.PathCalculator.graphDirty = true
+        else
+            QR.PathCalculator:OnInventoryChanged()
+        end
+    end
+
+    if QR.debugMode then
+        local count = PlayerInventory:GetTeleportCount()
+        QR:Debug(string_format("Inventory updated (%d teleports)", count))
+    end
+end
+
+--- Register the leave-combat callback. Called from Initialize rather than file
+-- scope: QR:RegisterCombatCallback lives in QuickRoute.lua, which the .toc
+-- loads after this file.
+function PlayerInventory:RegisterCombatCallback()
+    if self.combatCallbackRegistered or not QR.RegisterCombatCallback then return end
+    self.combatCallbackRegistered = true
+    QR:RegisterCombatCallback(nil, function()
+        if PlayerInventory.scanDeferredByCombat then
+            PlayerInventory:RunDeferredScan()
+        end
+    end)
+end
+
 eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- Preserve capability/equipment invalidation even when this event joins a
     -- pending BAG_UPDATE batch (e.g. looting and learning a riding spell).
@@ -615,31 +659,16 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
 
     -- Set a new timer
     debounceTimer = C_Timer.NewTimer(DEBOUNCE_DELAY, function()
-        PlayerInventory.pendingScan = false
-        local force = forceGraphRefresh
-        forceGraphRefresh = false
-
-        -- Skip scan if addon not fully initialized yet
-        if not QR.db then return end
-
-        -- Perform the scan
-        local before = not force and PlayerInventory:GetAllTeleports()
-        PlayerInventory:ScanAll()
-        local changed = force or not SameTeleports(before, PlayerInventory:GetAllTeleports())
-
-        -- Notify PathCalculator if it exists (defer during combat to avoid expensive graph rebuild)
-        if changed and QR.PathCalculator and QR.PathCalculator.OnInventoryChanged then
-            if InCombatLockdown() then
-                QR.PathCalculator.graphDirty = true
-            else
-                QR.PathCalculator:OnInventoryChanged()
-            end
+        -- Bags, spells and cooldowns churn constantly during a fight, and
+        -- scanning them walks every bag slot and every known teleport. Leaving
+        -- pendingScan set makes the rest of the fight's events fold into this
+        -- one deferred scan, which the leave-combat callback then runs; the
+        -- accumulated forceGraphRefresh stays set for it too.
+        if InCombatLockdown() then
+            PlayerInventory.scanDeferredByCombat = true
+            return
         end
-
-        if QR.debugMode then
-            local count = PlayerInventory:GetTeleportCount()
-            QR:Debug(string_format("Inventory updated (%d teleports)", count))
-        end
+        PlayerInventory:RunDeferredScan()
     end)
 end)
 

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -609,7 +609,9 @@ function PlayerInventory:RunDeferredScan()
     PlayerInventory:ScanAll()
     local changed = force or not SameTeleports(before, PlayerInventory:GetAllTeleports())
 
-    -- Notify PathCalculator if it exists (defer during combat to avoid expensive graph rebuild)
+    -- Notify PathCalculator if it exists. The combat branch is a backstop: the
+    -- callers below only reach here out of combat, but a fight can start
+    -- between that check and this line, and a rebuild is the expensive part.
     if changed and QR.PathCalculator and QR.PathCalculator.OnInventoryChanged then
         if InCombatLockdown() then
             QR.PathCalculator.graphDirty = true
@@ -641,6 +643,16 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- Preserve capability/equipment invalidation even when this event joins a
     -- pending BAG_UPDATE batch (e.g. looting and learning a riding spell).
     if event ~= "BAG_UPDATE" then forceGraphRefresh = true end
+
+    -- A deferred scan is normally run by the leave-combat callback. If that
+    -- never arrives -- a reload or a logout while fighting ends the fight
+    -- without PLAYER_REGEN_ENABLED reaching this session -- pendingScan would
+    -- stay set, and the guard below would then swallow every inventory event
+    -- for the rest of the session. Any event that finds work owed and no fight
+    -- in progress settles it.
+    if PlayerInventory.scanDeferredByCombat and not InCombatLockdown() then
+        PlayerInventory:RunDeferredScan()
+    end
     if event == "SKILL_LINES_CHANGED" and QR.PlayerInfo then
         QR.PlayerInfo:InvalidateCache()
     end

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -648,10 +648,13 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- never arrives -- a reload or a logout while fighting ends the fight
     -- without PLAYER_REGEN_ENABLED reaching this session -- pendingScan would
     -- stay set, and the guard below would then swallow every inventory event
-    -- for the rest of the session. Any event that finds work owed and no fight
-    -- in progress settles it.
+    -- for the rest of the session. Releasing both flags lets this event arm a
+    -- timer as usual, so the recovered scan is still debounced rather than run
+    -- inside an event handler. forceGraphRefresh is untouched and still
+    -- carries what the fight accumulated.
     if PlayerInventory.scanDeferredByCombat and not InCombatLockdown() then
-        PlayerInventory:RunDeferredScan()
+        PlayerInventory.scanDeferredByCombat = false
+        PlayerInventory.pendingScan = false
     end
     if event == "SKILL_LINES_CHANGED" and QR.PlayerInfo then
         QR.PlayerInfo:InvalidateCache()

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -59,11 +59,15 @@ local INVALIDATING_EVENTS = {
 --
 -- The divisor decides how far the player walks before every tracked quest is
 -- routed again, and each of those is a Dijkstra run over the whole graph. At
--- 1000 a bucket is a few yards across, so ordinary walking recomputed
--- everything several times a second. The two decisions the bucket exists for --
--- the zone changed, or the objective is now close enough to walk to -- are both
--- answered by a coarse grid, and the mapID in the key covers the first one on
--- its own.
+-- 1000 a bucket was a few yards across, so ordinary walking recomputed
+-- everything several times a second -- both here and through the movement
+-- probe in OnMovementUpdate, which compares the same bucket.
+--
+-- Of the two decisions the bucket exists for, the zone change is carried by the
+-- mapID in the key on its own. The other -- the objective is now close enough
+-- to walk to -- is not answered by any divisor: CACHE_TTL already expires every
+-- entry within 30 seconds regardless of where the player stands, so that is
+-- what bounds how stale this choice can get, and it did so at 1000 too.
 local POSITION_BUCKETS = 20
 
 local function GetPositionBucket()

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -779,7 +779,24 @@ function QTB:RegisterEvents()
     self.eventFrame:SetScript("OnEvent", function(frame, event, ...)
         -- Quest targets can change during combat or while this feature is
         -- disabled. Invalidate Lua state now; defer all button work.
-        if InCombatLockdown() or not QTB.enabled then QTB:InvalidateCache(); return end
+        if InCombatLockdown() then
+            -- Which quests are tracked can change mid-fight, and a route cached
+            -- for a quest that is no longer tracked is wrong in a way no field
+            -- of the cache key can show. Everything else keeps its cache:
+            -- emptying it here does not save a frame during the fight, it moves
+            -- a full recompute of every tracked quest to the moment the fight
+            -- ends, on top of the scan and the graph rebuild that land there.
+            -- SPELL_UPDATE_COOLDOWN stays out of it because confirming one
+            -- means walking the teleport list, which is the work combat is
+            -- meant to avoid; the first firing after the fight settles it.
+            if event == "QUEST_WATCH_LIST_CHANGED" or event == "SUPER_TRACKING_CHANGED" then
+                QTB:InvalidateCache()
+            else
+                QTB:CancelRefresh()
+            end
+            return
+        end
+        if not QTB.enabled then QTB:InvalidateCache(); return end
         if event == "SPELL_UPDATE_COOLDOWN" and not UpdateCooldownState() then return end
 
         -- Only the events that change WHICH quests are tracked empty the cache.

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -36,8 +36,36 @@ QR.QuestTeleportButtons = {
 
 local QTB = QR.QuestTeleportButtons
 
+-- Events after which a cached route may be wrong in a way no field of the cache
+-- key can show. Both change which quests exist to route to, and a stale entry
+-- would then belong to a quest that is no longer tracked. SPELL_UPDATE_COOLDOWN
+-- joins them only once UpdateCooldownState has confirmed a cooldown really
+-- moved: a teleport coming off cooldown can beat the one a cached entry chose,
+-- and the read path only re-checks the cooldown of the teleport already cached.
+--
+-- SPELLS_CHANGED and BAG_UPDATE_DELAYED are deliberately absent. A teleport
+-- appearing or disappearing reaches the graph through PlayerInventory's rescan,
+-- which builds a new graph, and every cached entry records the graph it was
+-- computed against -- so those invalidate themselves, without paying for the
+-- far more common firings that change no teleport at all.
+local INVALIDATING_EVENTS = {
+    QUEST_WATCH_LIST_CHANGED = true,
+    SUPER_TRACKING_CHANGED = true,
+    SPELL_UPDATE_COOLDOWN = true,
+}
+
 -- A small stable bucket avoids sub-pixel movement invalidating all quest
 -- routes, while approaching an objective can replace a teleport with walking.
+--
+-- The divisor decides how far the player walks before every tracked quest is
+-- routed again, and each of those is a Dijkstra run over the whole graph. At
+-- 1000 a bucket is a few yards across, so ordinary walking recomputed
+-- everything several times a second. The two decisions the bucket exists for --
+-- the zone changed, or the objective is now close enough to walk to -- are both
+-- answered by a coarse grid, and the mapID in the key covers the first one on
+-- its own.
+local POSITION_BUCKETS = 20
+
 local function GetPositionBucket()
     if not (C_Map and C_Map.GetBestMapForUnit and C_Map.GetPlayerMapPosition) then return nil end
     local ok, bucket = pcall(function()
@@ -50,7 +78,8 @@ local function GetPositionBucket()
         if position.GetXY then x, y = position:GetXY() end
         if (issecretvalue and (issecretvalue(x) or issecretvalue(y))) or type(x) ~= "number" or type(y) ~= "number"
             or x ~= x or y ~= y or x < 0 or x > 1 or y < 0 or y > 1 then return end
-        return string_format("%d:%d:%d", mapID, math_floor(x * 1000), math_floor(y * 1000))
+        return string_format("%d:%d:%d", mapID,
+            math_floor(x * POSITION_BUCKETS), math_floor(y * POSITION_BUCKETS))
     end)
     return ok and bucket or nil
 end
@@ -749,7 +778,26 @@ function QTB:RegisterEvents()
         if InCombatLockdown() or not QTB.enabled then QTB:InvalidateCache(); return end
         if event == "SPELL_UPDATE_COOLDOWN" and not UpdateCooldownState() then return end
 
-        QTB:InvalidateCache()
+        -- Only the events that change WHICH quests are tracked empty the cache.
+        -- Everything a cached entry depends on besides that -- the player's
+        -- position bucket, the graph it was computed against, whether the graph
+        -- is dirty, the entry's age, and the teleport's cooldown -- is checked
+        -- on every read, so a wholesale wipe here adds no freshness. It did
+        -- take all of it away: QUEST_LOG_UPDATE fires about once a second while
+        -- the player moves, and every firing then re-routed each tracked quest
+        -- from scratch, which is one Dijkstra run over the whole graph per
+        -- quest. Any addon that makes the client re-check quests, spells or
+        -- bags paid the same bill, which is why the cost grew with the number
+        -- of addons installed rather than with anything QuickRoute was asked to
+        -- do. See https://github.com/CybotTM/wow-quickroute/issues/66.
+        --
+        -- The in-flight refresh is still cancelled on every event: its results
+        -- describe the state before whatever just happened.
+        if INVALIDATING_EVENTS[event] then
+            QTB:InvalidateCache()
+        else
+            QTB:CancelRefresh()
+        end
 
         -- Debounce rapid QUEST_LOG_UPDATE events with a timer
         if QTB.debounceTimer then

--- a/QuickRoute/Modules/WaypointIntegration.lua
+++ b/QuickRoute/Modules/WaypointIntegration.lua
@@ -1133,7 +1133,7 @@ function WaypointIntegration:_ProcessWaypointChange()
     -- dropped -- the leave-combat callback registered in RegisterHooks runs it
     -- once, against the state the player is actually in by then.
     if InCombatLockdown() then
-        self._waypointChangePending = true
+        self._waypointChangePending = "changed"
         return
     end
     self._waypointChangePending = false
@@ -1167,18 +1167,35 @@ function WaypointIntegration:_ProcessWaypointChange()
     end
 end
 
+--- Run whichever waypoint work combat postponed, if any.
+-- Called by the leave-combat callback registered in RegisterHooks. Which of the
+-- two paths is owed matters: see the comment in OnWaypointCleared.
+function WaypointIntegration:ResumeDeferredWaypointWork()
+    local pending = self._waypointChangePending
+    self._waypointChangePending = false
+    if pending == "cleared" then
+        self:OnWaypointCleared()
+    elseif pending then
+        self:_ProcessWaypointChange()
+    end
+end
+
 --- Called when waypoint is cleared
 function WaypointIntegration:OnWaypointCleared()
     QR:Debug("Waypoint cleared")
 
     -- Redrawing the route costs the same graph search as computing one, so it
-    -- waits for the fight to end like every other route work. Deferred through
-    -- the same flag: the leave-combat callback re-reads the waypoint, which by
-    -- then reflects whether it is still cleared.
+    -- waits for the fight to end like every other route work. The flag records
+    -- WHICH work is owed, because the two are not interchangeable: a clear only
+    -- ever refreshes a window that is already open, while a change may open one
+    -- when auto-destination is on. Resuming a clear through the change path
+    -- would pop the route window up after every fight in which the player
+    -- removed their map pin.
     if InCombatLockdown() then
-        self._waypointChangePending = true
+        self._waypointChangePending = "cleared"
         return
     end
+    self._waypointChangePending = false
 
     -- Update UI if showing
     if QR.UI and QR.UI.frame and QR.UI.frame:IsShown() then
@@ -1204,9 +1221,7 @@ function WaypointIntegration:RegisterHooks()
     -- QuickRoute.lua, which the .toc loads after this file.
     if QR.RegisterCombatCallback then
         QR:RegisterCombatCallback(nil, function()
-            if WaypointIntegration._waypointChangePending then
-                WaypointIntegration:_ProcessWaypointChange()
-            end
+            WaypointIntegration:ResumeDeferredWaypointWork()
         end)
     end
 

--- a/QuickRoute/Modules/WaypointIntegration.lua
+++ b/QuickRoute/Modules/WaypointIntegration.lua
@@ -1127,6 +1127,17 @@ end
 
 --- Internal: process a waypoint change after debounce
 function WaypointIntegration:_ProcessWaypointChange()
+    -- Nothing here is worth a frame drop mid-fight: resolving the waypoint and
+    -- routing to it costs a search over the whole graph, and a route the player
+    -- cannot act on until the fight ends is not urgent. Remembered rather than
+    -- dropped -- the leave-combat callback registered in RegisterHooks runs it
+    -- once, against the state the player is actually in by then.
+    if InCombatLockdown() then
+        self._waypointChangePending = true
+        return
+    end
+    self._waypointChangePending = false
+
     local waypoint, source = self:GetActiveWaypoint()
 
     if waypoint then
@@ -1160,6 +1171,15 @@ end
 function WaypointIntegration:OnWaypointCleared()
     QR:Debug("Waypoint cleared")
 
+    -- Redrawing the route costs the same graph search as computing one, so it
+    -- waits for the fight to end like every other route work. Deferred through
+    -- the same flag: the leave-combat callback re-reads the waypoint, which by
+    -- then reflects whether it is still cleared.
+    if InCombatLockdown() then
+        self._waypointChangePending = true
+        return
+    end
+
     -- Update UI if showing
     if QR.UI and QR.UI.frame and QR.UI.frame:IsShown() then
         QR.UI:RefreshRoute()
@@ -1177,6 +1197,17 @@ function WaypointIntegration:RegisterHooks()
     -- Create event frame if not exists
     if not eventFrame then
         eventFrame = CreateFrame("Frame")
+    end
+
+    -- Run the waypoint change that combat postponed. Registered here rather
+    -- than at file scope because QR:RegisterCombatCallback is declared in
+    -- QuickRoute.lua, which the .toc loads after this file.
+    if QR.RegisterCombatCallback then
+        QR:RegisterCombatCallback(nil, function()
+            if WaypointIntegration._waypointChangePending then
+                WaypointIntegration:_ProcessWaypointChange()
+            end
+        end)
     end
 
     -- Register WoW events

--- a/QuickRoute/Modules/ZoneSurvey.lua
+++ b/QuickRoute/Modules/ZoneSurvey.lua
@@ -317,6 +317,14 @@ function ZoneSurvey:Initialize()
         frame.pending = true
         C_Timer.After(1.5, function()
             frame.pending = false
+            -- Dropped in combat, not postponed. A capture that runs once the
+            -- fight is over describes wherever the player ended up, which is
+            -- the invented evidence the comment above refuses; and the arrival
+            -- state it would have been measured against no longer applies.
+            if InCombatLockdown() then
+                ZoneSurvey:ForgetArrivalState()
+                return
+            end
             local ok, err = pcall(function() return ZoneSurvey:Capture() end)
             if not ok then
                 QR:Debug("ZoneSurvey capture failed: " .. tostring(err))

--- a/QuickRoute/QuickRoute.lua
+++ b/QuickRoute/QuickRoute.lua
@@ -223,6 +223,7 @@ function QR:OnPlayerLogin()
             { "TeleportDestinations", function() QR.TeleportDestinations:Initialize() end },
             { "Graph",              function() QR:InitializeGraph() end },
             { "PlayerTeleports",    function() QR:ScanPlayerTeleports() end },
+            { "InventoryCombat",    function() QR.PlayerInventory:RegisterCombatCallback() end },
             { "SecureButtons",      function() QR.SecureButtons:Initialize() end },
             { "WaypointIntegration",function() QR.WaypointIntegration:Initialize() end },
             { "MainFrame",          function() QR.MainFrame:Initialize() end },

--- a/tests/test_combat_idle.lua
+++ b/tests/test_combat_idle.lua
@@ -86,6 +86,17 @@ end
 -- Cost during combat: there is to be none
 -------------------------------------------------------------------------------
 
+-- Everything below postpones work to a leave-combat callback. If a module's
+-- callback is never registered, the postponement silently becomes a drop -- and
+-- for the inventory scan, a permanent one. Both registrations happen during
+-- addon initialization, so a missing init entry shows up here.
+T:run("the modules that postpone work registered their leave-combat callback", function(t)
+    t:assertTrue(QR.WaypointIntegration.hooksRegistered,
+        "WaypointIntegration:RegisterHooks ran, which registers its callback")
+    t:assertTrue(QR.PlayerInventory.combatCallbackRegistered,
+        "PlayerInventory:RegisterCombatCallback ran")
+end)
+
 T:run("no route is calculated during combat", function(t)
     withCountedRoutes(function()
         routesFor("QUEST_LOG_UPDATE") -- warm, out of combat

--- a/tests/test_combat_idle.lua
+++ b/tests/test_combat_idle.lua
@@ -39,6 +39,7 @@ local function withCountedRoutes(body)
         MockWoW.config.questWaypoints[id] = { mapID = 84, x = 0.5, y = 0.5 }
         MockWoW.config.questTitles[id] = "Budget quest " .. id
     end
+    saved.knownSpell = MockWoW.config.knownSpells[3561]
     MockWoW.config.knownSpells[3561] = true
     QR.PlayerInventory:ScanAll()
 
@@ -69,6 +70,7 @@ local function withCountedRoutes(body)
     MockWoW.config.questTitles = saved.titles
     QR.PathCalculator.CalculatePath = saved.calculate
     QR.PathCalculator.graphDirty = saved.graphDirty
+    MockWoW.config.knownSpells[3561] = saved.knownSpell
     QTB.enabled = saved.enabled
     if not ok then error(err, 0) end
 end
@@ -124,19 +126,66 @@ T:run("the zone survey does not record during combat", function(t)
     QR.db.zoneSurveyEnabled = savedEnabled
 end)
 
+T:run("a waypoint cleared in combat does not open the window afterwards", function(t)
+    local WI = QR.WaypointIntegration
+    local savedCombat, savedAuto = MockWoW.config.inCombatLockdown, QR.db.autoDestination
+    local savedShowing = QR.MainFrame.isShowing
+    local shows = 0
+    local realShow = QR.MainFrame.Show
+    QR.MainFrame.Show = function(self, ...) shows = shows + 1; return realShow(self, ...) end
+
+    -- Auto-destination opens the route window on a waypoint CHANGE. Clearing a
+    -- map pin never did, and must not start doing so just because the clear was
+    -- postponed by a fight.
+    QR.db.autoDestination = true
+    if QR.MainFrame.frame then QR.MainFrame.frame:Hide() end
+    QR.MainFrame.isShowing = false
+    WI._waypointChangePending = false
+
+    MockWoW.config.inCombatLockdown = true
+    WI:OnWaypointCleared()
+    t:assertEqual("cleared", WI._waypointChangePending, "the clear is remembered as a clear")
+
+    MockWoW.config.inCombatLockdown = false
+    shows = 0
+    WI:ResumeDeferredWaypointWork() -- what the leave-combat callback calls
+    t:assertEqual(0, shows, "resuming a clear leaves a closed window closed")
+    t:assertFalse(WI._waypointChangePending, "and the owed work is consumed")
+
+    QR.MainFrame.Show = realShow
+    QR.MainFrame.isShowing = savedShowing
+    MockWoW.config.inCombatLockdown = savedCombat
+    QR.db.autoDestination = savedAuto
+    WI._waypointChangePending = false
+end)
+
 T:run("a waypoint change in combat waits for the fight to end", function(t)
     withCountedRoutes(function()
         local WI = QR.WaypointIntegration
         WI._waypointChangePending = false
+        -- Auto-destination is what turns a waypoint change into a route, so the
+        -- test states it rather than inheriting whatever the suite left.
+        -- Auto-destination is what makes a waypoint change reach the UI, so the
+        -- test states it rather than inheriting whatever the suite left. The
+        -- observable effect of the change path is that call: the clear path
+        -- never makes it, which is what the test above pins.
+        local savedAuto = QR.db.autoDestination
+        QR.db.autoDestination = true
+        local shows = 0
+        local realShow = QR.UI.Show
+        QR.UI.Show = function(self, ...) shows = shows + 1; return realShow(self, ...) end
 
         MockWoW.config.inCombatLockdown = true
         routeCalls = 0
         WI:_ProcessWaypointChange()
         t:assertEqual(0, routeCalls, "no route is computed while the player is fighting")
-        t:assertTrue(WI._waypointChangePending, "but the change is remembered")
+        t:assertEqual("changed", WI._waypointChangePending, "but the change is remembered as a change")
 
         MockWoW.config.inCombatLockdown = false
-        WI:_ProcessWaypointChange()
+        WI:ResumeDeferredWaypointWork() -- what the leave-combat callback calls
         t:assertFalse(WI._waypointChangePending, "and is consumed once the fight is over")
+        t:assertEqual(1, shows, "and the change path is the one that runs")
+        QR.UI.Show = realShow
+        QR.db.autoDestination = savedAuto
     end)
 end)

--- a/tests/test_combat_idle.lua
+++ b/tests/test_combat_idle.lua
@@ -1,0 +1,142 @@
+-------------------------------------------------------------------------------
+-- test_combat_idle.lua
+-- QuickRoute is to do nothing at all while the player is fighting. Not less --
+-- nothing: no route, no bag walk, no survey record. Work postponed this way
+-- must still happen once the fight ends rather than being dropped, except
+-- where running it late would record something untrue.
+--
+-- Events are delivered to each module's own frame rather than through
+-- MockWoW:FireEvent, because MockWoW:Reset in an earlier file empties the
+-- dispatch registry and orphans every frame registered before it.
+-------------------------------------------------------------------------------
+
+local T, QR, MockWoW = ...
+
+local QTB = QR.QuestTeleportButtons
+
+local routeCalls = 0
+
+--- Three tracked quests, a teleport that reaches them, and a counted stand-in
+-- for the route planner. Restores everything it touched.
+local function withCountedRoutes(body)
+    local saved = {
+        inCombat = MockWoW.config.inCombatLockdown,
+        playerX = MockWoW.config.playerX,
+        playerY = MockWoW.config.playerY,
+        watches = MockWoW.config.questWatches,
+        waypoints = MockWoW.config.questWaypoints,
+        titles = MockWoW.config.questTitles,
+        calculate = QR.PathCalculator.CalculatePath,
+        enabled = QTB.enabled,
+    }
+
+    MockWoW.config.inCombatLockdown = false
+    MockWoW.config.playerX, MockWoW.config.playerY = 0.5, 0.5
+    MockWoW.config.questWatches = { 71001, 71002, 71003 }
+    MockWoW.config.questWaypoints = {}
+    MockWoW.config.questTitles = {}
+    for _, id in ipairs(MockWoW.config.questWatches) do
+        MockWoW.config.questWaypoints[id] = { mapID = 84, x = 0.5, y = 0.5 }
+        MockWoW.config.questTitles[id] = "Budget quest " .. id
+    end
+    MockWoW.config.knownSpells[3561] = true
+    QR.PlayerInventory:ScanAll()
+
+    -- Every cached route records the graph it was computed against and is
+    -- discarded while a rebuild is pending. Both are shared with the rest of
+    -- the suite, so this file states what it needs rather than inheriting it.
+    saved.graphDirty = QR.PathCalculator.graphDirty
+    if not QR.PathCalculator.graph then QR.PathCalculator:BuildGraph() end
+    QR.PathCalculator.graphDirty = false
+
+    QTB.enabled = true
+    if not QTB.initialized then QTB:Initialize() end
+    QTB:InvalidateCache()
+
+    -- Counted rather than real: this file is about how many routes are asked
+    -- for, and the real ones are slow enough to dominate the suite.
+    QR.PathCalculator.CalculatePath = function()
+        routeCalls = routeCalls + 1
+        return { steps = { { type = "teleport", teleportID = 3561, sourceType = "spell" } } }
+    end
+
+    local ok, err = pcall(body)
+
+    MockWoW.config.inCombatLockdown = saved.inCombat
+    MockWoW.config.playerX, MockWoW.config.playerY = saved.playerX, saved.playerY
+    MockWoW.config.questWatches = saved.watches
+    MockWoW.config.questWaypoints = saved.waypoints
+    MockWoW.config.questTitles = saved.titles
+    QR.PathCalculator.CalculatePath = saved.calculate
+    QR.PathCalculator.graphDirty = saved.graphDirty
+    QTB.enabled = saved.enabled
+    if not ok then error(err, 0) end
+end
+
+--- Route calculations caused by delivering one event to the module.
+local function routesFor(event)
+    routeCalls = 0
+    QTB.eventFrame:GetScript("OnEvent")(QTB.eventFrame, event)
+    return routeCalls
+end
+
+-------------------------------------------------------------------------------
+-- Cost during combat: there is to be none
+-------------------------------------------------------------------------------
+
+T:run("no route is calculated during combat", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE") -- warm, out of combat
+        MockWoW.config.inCombatLockdown = true
+        for _, event in ipairs({
+            "QUEST_LOG_UPDATE", "QUEST_WATCH_LIST_CHANGED", "SUPER_TRACKING_CHANGED",
+            "ZONE_CHANGED_NEW_AREA", "SPELLS_CHANGED", "BAG_UPDATE_DELAYED",
+            "SPELL_UPDATE_COOLDOWN",
+        }) do
+            t:assertEqual(0, routesFor(event), event .. " must route nothing in combat")
+        end
+    end)
+end)
+
+T:run("the zone survey does not record during combat", function(t)
+    local ZS = QR.ZoneSurvey
+    local savedCombat, savedEnabled = MockWoW.config.inCombatLockdown, QR.db.zoneSurveyEnabled
+    local savedCapture = ZS.Capture
+    local captures = 0
+    ZS.Capture = function(self, ...) captures = captures + 1; return savedCapture(self, ...) end
+    QR.db.zoneSurveyEnabled = true
+
+    local handler = ZS.frame and ZS.frame:GetScript("OnEvent")
+    t:assertNotNil(handler, "the survey has an event handler to drive")
+
+    MockWoW.config.inCombatLockdown = true
+    handler(ZS.frame, "ZONE_CHANGED_NEW_AREA")
+    t:assertEqual(0, captures, "a border crossed mid-fight is not written to disk")
+
+    -- Dropped rather than deferred: run later it would describe wherever the
+    -- fight ended, which is not the crossing it was meant to record.
+    MockWoW.config.inCombatLockdown = false
+    handler(ZS.frame, "ZONE_CHANGED_NEW_AREA")
+    t:assertEqual(1, captures, "out of combat it records as before")
+
+    ZS.Capture = savedCapture
+    MockWoW.config.inCombatLockdown = savedCombat
+    QR.db.zoneSurveyEnabled = savedEnabled
+end)
+
+T:run("a waypoint change in combat waits for the fight to end", function(t)
+    withCountedRoutes(function()
+        local WI = QR.WaypointIntegration
+        WI._waypointChangePending = false
+
+        MockWoW.config.inCombatLockdown = true
+        routeCalls = 0
+        WI:_ProcessWaypointChange()
+        t:assertEqual(0, routeCalls, "no route is computed while the player is fighting")
+        t:assertTrue(WI._waypointChangePending, "but the change is remembered")
+
+        MockWoW.config.inCombatLockdown = false
+        WI:_ProcessWaypointChange()
+        t:assertFalse(WI._waypointChangePending, "and is consumed once the fight is over")
+    end)
+end)

--- a/tests/test_inventory_graph_invalidation.lua
+++ b/tests/test_inventory_graph_invalidation.lua
@@ -92,6 +92,26 @@ for _, event in ipairs({ "PLAYER_EQUIPMENT_CHANGED", "SPELLS_CHANGED", "TOYS_UPD
     end)
 end
 
+-- The leave-combat callback normally runs the postponed scan. A reload or a
+-- logout mid-fight ends the fight without PLAYER_REGEN_ENABLED reaching this
+-- session, and the pending flag that coalesces a fight's events would then
+-- suppress every later scan for good.
+T:run("Inventory events: a deferred scan is not lost when leaving combat goes unseen", function(t)
+    withInventoryEvents(function(f)
+        MockWoW.config.inCombatLockdown = true
+        f.fire("BAG_UPDATE"); f.flush()
+        t:assertEqual(0, (f.counts()), "nothing scanned during the fight")
+
+        -- No PLAYER_REGEN_ENABLED, no callback: just the next inventory event.
+        MockWoW.config.inCombatLockdown = false
+        f.replace({})
+        f.fire("BAG_UPDATE"); f.flush()
+        local scans, notifications = f.counts()
+        t:assertTrue(scans > 0, "the next event out of combat settles the owed scan")
+        t:assertEqual(1, notifications, "and the inventory change is still noticed")
+    end)
+end)
+
 -- Combat used to scan and merely postpone the rebuild. It now postpones the
 -- scan as well: walking every bag slot is itself work the player is not asking
 -- for mid-fight, and the events that provoke it -- loot, buffs, cooldowns --

--- a/tests/test_inventory_graph_invalidation.lua
+++ b/tests/test_inventory_graph_invalidation.lua
@@ -92,15 +92,27 @@ for _, event in ipairs({ "PLAYER_EQUIPMENT_CHANGED", "SPELLS_CHANGED", "TOYS_UPD
     end)
 end
 
-T:run("Inventory events: combat skips unchanged loot but defers real inventory changes", function(t)
+-- Combat used to scan and merely postpone the rebuild. It now postpones the
+-- scan as well: walking every bag slot is itself work the player is not asking
+-- for mid-fight, and the events that provoke it -- loot, buffs, cooldowns --
+-- arrive constantly while fighting. What must not change is that a real
+-- inventory change is not lost, only deferred.
+T:run("Inventory events: combat does not scan at all, and the change survives it", function(t)
     withInventoryEvents(function(f)
         MockWoW.config.inCombatLockdown, QR.PathCalculator.graphDirty = true, false
-        f.fire("BAG_UPDATE"); f.flush()
-        t:assertFalse(QR.PathCalculator.graphDirty, "Unchanged loot does not queue a post-combat graph rebuild")
         f.replace({})
         f.fire("BAG_UPDATE"); f.flush()
-        t:assertTrue(QR.PathCalculator.graphDirty, "Removed teleport queues a post-combat graph rebuild")
-        local _, notifications = f.counts()
+        local scans, notifications = f.counts()
+        t:assertEqual(0, scans, "A fight is not the time to walk every bag slot")
+        t:assertFalse(QR.PathCalculator.graphDirty, "and nothing is invalidated mid-fight either")
         t:assertEqual(0, notifications, "Combat never invokes the normal inventory-change callback")
+        t:assertTrue(QR.PlayerInventory.scanDeferredByCombat, "the scan is remembered, not dropped")
+
+        -- What the leave-combat callback does once the fight ends.
+        MockWoW.config.inCombatLockdown = false
+        QR.PlayerInventory:RunDeferredScan()
+        scans, notifications = f.counts()
+        t:assertEqual(1, scans, "The postponed scan runs exactly once afterwards")
+        t:assertEqual(1, notifications, "and the removed teleport invalidates the routes then")
     end)
 end)

--- a/tests/test_questbutton_async.lua
+++ b/tests/test_questbutton_async.lua
@@ -414,7 +414,13 @@ T:run("Quest button movement probe: coalesces active batches and runs without vi
     end)
 end)
 
-T:run("Quest button cache: quest events during combat invalidate targets without secure work", function(t)
+-- The wipe this used to assert on QUEST_LOG_UPDATE was the blanket
+-- invalidation removed for issue #66: every field a cached entry depends on is
+-- checked when it is read, in combat as out of it, so emptying the cache here
+-- bought no freshness and moved a full recompute of every tracked quest to the
+-- moment the fight ended. What a fight can still change is which quests are
+-- tracked, and that is asserted below.
+T:run("Quest button cache: quest events during combat do no secure work, and only a tracked-set change invalidates", function(t)
     withRefresh(function(qtb,state)
         state.watched={10001}
         qtb:RefreshButtons()
@@ -428,9 +434,13 @@ T:run("Quest button cache: quest events during combat invalidate targets without
         local writes=state.writes
         MockWoW.config.inCombatLockdown=true
         callback(frame,"QUEST_LOG_UPDATE")
-        t:assertNil(qtb.questCache[10001],"Quest changes in combat invalidate stale target coordinates")
+        t:assertNotNil(qtb.questCache[10001],"An ordinary quest event in combat keeps the cached target")
         t:assertEqual(writes,state.writes,"Combat quest events perform no protected attribute writes")
         t:assertEqual(1,state.calls,"Combat quest event schedules no route calculation")
+        callback(frame,"QUEST_WATCH_LIST_CHANGED")
+        t:assertNil(qtb.questCache[10001],"A change to which quests are tracked does invalidate, in combat too")
+        t:assertEqual(writes,state.writes,"and still performs no protected attribute writes")
+        t:assertEqual(1,state.calls,"and still schedules no route calculation")
         frame:UnregisterAllEvents()
         qtb.eventFrame=oldEvent
     end)

--- a/tests/test_route_recompute_budget.lua
+++ b/tests/test_route_recompute_budget.lua
@@ -40,6 +40,7 @@ local function withCountedRoutes(body)
         MockWoW.config.questWaypoints[id] = { mapID = 84, x = 0.5, y = 0.5 }
         MockWoW.config.questTitles[id] = "Budget quest " .. id
     end
+    saved.knownSpell = MockWoW.config.knownSpells[3561]
     MockWoW.config.knownSpells[3561] = true
     QR.PlayerInventory:ScanAll()
 
@@ -70,6 +71,7 @@ local function withCountedRoutes(body)
     MockWoW.config.questTitles = saved.titles
     QR.PathCalculator.CalculatePath = saved.calculate
     QR.PathCalculator.graphDirty = saved.graphDirty
+    MockWoW.config.knownSpells[3561] = saved.knownSpell
     QTB.enabled = saved.enabled
     if not ok then error(err, 0) end
 end

--- a/tests/test_route_recompute_budget.lua
+++ b/tests/test_route_recompute_budget.lua
@@ -1,0 +1,138 @@
+-------------------------------------------------------------------------------
+-- test_route_recompute_budget.lua
+-- How often QuickRoute is allowed to route again, and when it must not route at
+-- all. Both are about cost rather than about a result: routing one quest is a
+-- Dijkstra run over the whole graph, so a handler that does it once per tracked
+-- quest, once a second, is a stutter -- see
+-- https://github.com/CybotTM/wow-quickroute/issues/66.
+--
+-- Events are delivered to the module's own frame rather than through
+-- MockWoW:FireEvent, because MockWoW:Reset in an earlier file empties the
+-- dispatch registry and orphans every frame registered before it.
+-------------------------------------------------------------------------------
+
+local T, QR, MockWoW = ...
+
+local QTB = QR.QuestTeleportButtons
+
+local routeCalls = 0
+
+--- Three tracked quests, a teleport that reaches them, and a counted stand-in
+-- for the route planner. Restores everything it touched.
+local function withCountedRoutes(body)
+    local saved = {
+        inCombat = MockWoW.config.inCombatLockdown,
+        playerX = MockWoW.config.playerX,
+        playerY = MockWoW.config.playerY,
+        watches = MockWoW.config.questWatches,
+        waypoints = MockWoW.config.questWaypoints,
+        titles = MockWoW.config.questTitles,
+        calculate = QR.PathCalculator.CalculatePath,
+        enabled = QTB.enabled,
+    }
+
+    MockWoW.config.inCombatLockdown = false
+    MockWoW.config.playerX, MockWoW.config.playerY = 0.5, 0.5
+    MockWoW.config.questWatches = { 71001, 71002, 71003 }
+    MockWoW.config.questWaypoints = {}
+    MockWoW.config.questTitles = {}
+    for _, id in ipairs(MockWoW.config.questWatches) do
+        MockWoW.config.questWaypoints[id] = { mapID = 84, x = 0.5, y = 0.5 }
+        MockWoW.config.questTitles[id] = "Budget quest " .. id
+    end
+    MockWoW.config.knownSpells[3561] = true
+    QR.PlayerInventory:ScanAll()
+
+    -- Every cached route records the graph it was computed against and is
+    -- discarded while a rebuild is pending. Both are shared with the rest of
+    -- the suite, so this file states what it needs rather than inheriting it.
+    saved.graphDirty = QR.PathCalculator.graphDirty
+    if not QR.PathCalculator.graph then QR.PathCalculator:BuildGraph() end
+    QR.PathCalculator.graphDirty = false
+
+    QTB.enabled = true
+    if not QTB.initialized then QTB:Initialize() end
+    QTB:InvalidateCache()
+
+    -- Counted rather than real: this file is about how many routes are asked
+    -- for, and the real ones are slow enough to dominate the suite.
+    QR.PathCalculator.CalculatePath = function()
+        routeCalls = routeCalls + 1
+        return { steps = { { type = "teleport", teleportID = 3561, sourceType = "spell" } } }
+    end
+
+    local ok, err = pcall(body)
+
+    MockWoW.config.inCombatLockdown = saved.inCombat
+    MockWoW.config.playerX, MockWoW.config.playerY = saved.playerX, saved.playerY
+    MockWoW.config.questWatches = saved.watches
+    MockWoW.config.questWaypoints = saved.waypoints
+    MockWoW.config.questTitles = saved.titles
+    QR.PathCalculator.CalculatePath = saved.calculate
+    QR.PathCalculator.graphDirty = saved.graphDirty
+    QTB.enabled = saved.enabled
+    if not ok then error(err, 0) end
+end
+
+--- Route calculations caused by delivering one event to the module.
+local function routesFor(event)
+    routeCalls = 0
+    QTB.eventFrame:GetScript("OnEvent")(QTB.eventFrame, event)
+    return routeCalls
+end
+
+-------------------------------------------------------------------------------
+-- Cost while moving
+-------------------------------------------------------------------------------
+
+T:run("standing still, a repeated QUEST_LOG_UPDATE routes nothing again", function(t)
+    withCountedRoutes(function()
+        t:assertTrue(routesFor("QUEST_LOG_UPDATE") > 0, "the first firing computes the routes")
+        t:assertEqual(0, routesFor("QUEST_LOG_UPDATE"), "a second identical firing reuses them")
+        t:assertEqual(0, routesFor("QUEST_LOG_UPDATE"), "and so does a third")
+    end)
+end)
+
+T:run("walking does not re-route on every QUEST_LOG_UPDATE", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        -- Twenty firings while running: about a second of play, and two per
+        -- cent of the map crossed.
+        local total = 0
+        for _ = 1, 20 do
+            MockWoW.config.playerX = MockWoW.config.playerX + 0.001
+            total = total + routesFor("QUEST_LOG_UPDATE")
+        end
+        t:assertEqual(0, total, "small steps do not invalidate any quest's route")
+    end)
+end)
+
+T:run("crossing the zone does route again", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        MockWoW.config.playerX = 0.95 -- far side of the zone
+        t:assertTrue(routesFor("QUEST_LOG_UPDATE") > 0,
+            "a teleport worth taking from here may not be worth it from there")
+    end)
+end)
+
+T:run("changing zone routes again, even at the same coordinates", function(t)
+    withCountedRoutes(function()
+        local savedMap = MockWoW.config.currentMapID
+        routesFor("QUEST_LOG_UPDATE")
+        -- Same x and y, different zone: every zone's coordinates run 0..1, so a
+        -- position key that does not name the map cannot tell these apart.
+        MockWoW.config.currentMapID = 85
+        local routed = routesFor("QUEST_LOG_UPDATE")
+        MockWoW.config.currentMapID = savedMap
+        t:assertTrue(routed > 0, "a route from another zone is a different route")
+    end)
+end)
+
+T:run("a change to which quests are tracked routes again", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        t:assertTrue(routesFor("QUEST_WATCH_LIST_CHANGED") > 0,
+            "the tracked set changed, so a cached route may belong to no quest")
+    end)
+end)


### PR DESCRIPTION
Fixes the stutter reported in #66, and stops the addon working through fights.

## What was happening

`QuestTeleportButtons` picks each tracked quest's teleport out of a computed route, and caches that per quest. The cache could never be hit: the event handler wiped it wholesale on every event it listens to, and `QUEST_LOG_UPDATE` is one of them. That event fires about once a second while the player moves, so each firing routed every tracked quest again from scratch — one Dijkstra run over a 278-node, 3237-edge graph per quest. The position bucket in the cache key was a thousandth of the map, a few yards, so anything that survived the wipe was invalidated by walking anyway.

That matches the report exactly: nothing while standing still, a hitch about once a second while moving, no QuickRoute window involved. It also explains why the cost grew as more addons were installed — the expensive path hangs off events any addon can provoke by asking the client about quests, spells or bags, and each firing paid full price.

Separately, none of this stopped for combat, and neither did the rest of the addon.

## Measurements

`scripts/benchmark_movement.lua`, the repository's own movement benchmark — 25 tracked quests, QuickRoute window closed, ten simulated seconds at 60 fps. `de47ddf` versus this branch, same host. Standalone Lua CPU, not in-client FPS.

| workload | before | after |
|---|---|---|
| moving | 226 routes, 227.8 ms, worst frame 3.70 ms | 50 routes, 54.4 ms, worst frame 1.66 ms |
| stationary, one quest event per second | 249 routes, 199.8 ms, worst frame 4.70 ms | **0 routes, 0.74 ms**, worst frame 0.02 ms |
| stationary, settled | 0 routes, 0.20 ms | 0 routes, 0.16 ms |
| initial warmup | 25 routes, 13.9 ms | 25 routes, 13.9 ms |

The second row is the reported bug: a quest event a second, going nowhere, previously cost ten routes a second. The first row keeps the routes that a real change of position earns — two bucket crossings across the fixture's path, times 25 quests.

The earlier movement work recorded in `docs/PERFORMANCE-REVIEW-2026-09-06.md` made each route cheaper and left their number alone ("226 in both"); this reduces the number.

Combat, measured separately by event with the same mock:

| in combat | before | after |
|---|---|---|
| `SUPER_TRACKING_CHANGED` | 40 ms, graph rebuild + route | nothing |
| map pin moved | 2.2 ms, route | nothing |
| bag / spell / toy / equipment / skill events | a full inventory scan each | nothing |
| zone crossing | survey record written | nothing |
| a fight of 20 events, 4 tracked quests | cache emptied, all 4 re-routed after | cache kept, none re-routed |
| on leaving combat | — | one scan, one route, once |

## What changed

**Recompute budget.** The cache wipe is limited to the events that change which quests are tracked, plus a cooldown change the module has already confirmed. Everything else a cached entry depends on — position bucket, the graph it was computed against, whether a rebuild is pending, the entry's age, the teleport's cooldown — is checked on every read, so those events lost no freshness by not wiping. `SPELLS_CHANGED` and `BAG_UPDATE_DELAYED` invalidate themselves through the graph identity the entries record. The position bucket became a named constant at 20 per axis; `CACHE_TTL` is what bounds staleness, at 30 seconds, and did so at the old divisor too.

Combat also stopped emptying the quest cache on every event: the handler returns without doing button work either way, so the wipe only moved a full recompute of every tracked quest to the moment the fight ended, next to the deferred scan and the graph rebuild. A change to which quests are tracked still invalidates mid-fight.

**Combat.** Three gates, deferring rather than dropping. A waypoint change is remembered and resumed by the leave-combat callback — the flag records *which* of the two paths is owed, because resuming a cleared pin through the change path would pop the route window open after any fight in which the player removed their pin. The inventory rescan leaves its pending flag set so a fight's events fold into one scan afterwards, carrying the accumulated forced-rebuild flag; if the leave-combat callback never arrives (a reload or logout mid-fight), the next inventory event releases the flags so the scan is not suppressed for the rest of the session. The zone survey is the exception and drops its record, because a capture run after the fight would describe wherever the player ended up — the invented evidence that recorder exists to avoid.

## Tests

`tests/test_route_recompute_budget.lua` and `tests/test_combat_idle.lua`. Every guard was watched to fail with its fix reverted. Two of those mutations were informative rather than confirming: one made the position bucket blind to the mapID and passed, which is why the same-coordinates-different-zone case exists; another showed the first cleared-waypoint test to be a no-op, because it re-implemented the dispatch instead of calling it — extracting `ResumeDeferredWaypointWork` from the callback closure is what let the test exercise the real thing.

Suite: 16028 → 16060 assertions, 0 failures, in both orders; luacheck clean.

One existing expectation changed deliberately. `test_inventory_graph_invalidation.lua` pinned "combat scans the bags but postpones the rebuild"; combat now postpones the scan as well, so it asserts the new contract — nothing during the fight, the change picked up in a single scan afterwards, still exactly one route invalidation.

## The trade-off this makes

A quest whose objective moves while the player stands still — an escort stepping into the next zone, say — can keep its previous teleport button for up to `CACHE_TTL`, 30 seconds, where before a quest event replaced it within the debounce. That bound is not new: `WaypointIntegration`'s own coordinate cache holds each quest's resolved position for the same 30 seconds, so re-routing on every quest event was recomputing from coordinates that were themselves up to 30 seconds old. Adding the resolved waypoint to the cache key would compare one 30-second-old value against another and buy nothing.

## Not addressed here

`PlayerInventory.lua:599` forces a graph rebuild for every event that is not `BAG_UPDATE`, bypassing the teleport-set comparison beside it. `SPELLS_CHANGED` therefore still costs about 75 ms out of combat: a full graph rebuild plus a route per tracked quest. Narrowing it needs a cheap capability signature to compare against — riding and flying are spells, so a naive narrowing would miss a player learning to fly — and that is a change to `TravelRequirements`, not to this fix.

I have not been able to confirm this is what the reporter of #66 hit; their version and settings are still unknown. The mechanism matches the video in every respect I could check.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
