### PR TITLE
perf: stop recomputing routes and re-asking the client, and key the quest cache on its destination

### DIFF
--- a/QuickRoute/Core/PathCalculator.lua
+++ b/QuickRoute/Core/PathCalculator.lua
@@ -147,10 +147,20 @@ end)
 -- @param nodeName string The graph node name (may contain English zone names)
 -- @param mapID number The map ID for the node
 -- @return string The localized display name
+-- A zone's name does not change while the player is logged in, and every step
+-- of every route asks for one: measured at 1430 identical queries a minute for
+-- two distinct maps. Keyed by node and map because the answer also depends on
+-- the node's own parenthetical.
+local localizedNodeNames = {}
+
 local function GetLocalizedNodeDisplayName(nodeName, mapID)
     if not mapID or not C_Map or not C_Map.GetMapInfo then
         return nodeName
     end
+
+    local memoKey = nodeName .. "\0" .. mapID
+    local remembered = localizedNodeNames[memoKey]
+    if remembered then return remembered end
 
     local mapInfo = C_Map.GetMapInfo(mapID)
     if not mapInfo or not mapInfo.name then
@@ -160,16 +170,18 @@ local function GetLocalizedNodeDisplayName(nodeName, mapID)
     local zoneName = mapInfo.name
 
     -- Check if node name has a parenthetical disambiguation (e.g., "Dalaran (Broken Isles)")
+    local display = zoneName
     local _, parenthetical = nodeName:match("^(.+)%s*%((.+)%)$")
     if parenthetical and mapInfo.parentMapID then
         -- Get the localized parent (continent/region) name
         local parentInfo = C_Map.GetMapInfo(mapInfo.parentMapID)
         if parentInfo and parentInfo.name and parentInfo.name ~= zoneName then
-            return zoneName .. " (" .. parentInfo.name .. ")"
+            display = zoneName .. " (" .. parentInfo.name .. ")"
         end
     end
 
-    return zoneName
+    localizedNodeNames[memoKey] = display
+    return display
 end
 
 -------------------------------------------------------------------------------

--- a/QuickRoute/Core/TravelTime.lua
+++ b/QuickRoute/Core/TravelTime.lua
@@ -303,9 +303,20 @@ function TravelTime:GetTeleportTime(teleportData, teleportID, sourceType)
         if ok and Number(itemSpellID) and itemSpellID > 0 then spellID = itemSpellID end
     end
     if spellID and C_Spell and C_Spell.GetSpellInfo then
-        local ok, info = pcall(C_Spell.GetSpellInfo, spellID)
-        if ok and type(info) == "table" and Number(info.castTime) then
-            castTime = info.castTime / 1000
+        -- A spell's cast time is static, and every route prices every teleport
+        -- it could take: measured at 1850 identical queries a minute for three
+        -- distinct spells. Remembered per spell, and dropped when the spellbook
+        -- changes, which is the only thing that could alter the answer.
+        local remembered = self.castTimeBySpell and self.castTimeBySpell[spellID]
+        if remembered then
+            castTime = remembered
+        else
+            local ok, info = pcall(C_Spell.GetSpellInfo, spellID)
+            if ok and type(info) == "table" and Number(info.castTime) then
+                castTime = info.castTime / 1000
+                self.castTimeBySpell = self.castTimeBySpell or {}
+                self.castTimeBySpell[spellID] = castTime
+            end
         end
     end
     return castTime + loadTime

--- a/QuickRoute/Modules/CooldownTracker.lua
+++ b/QuickRoute/Modules/CooldownTracker.lua
@@ -22,6 +22,10 @@ QR.CooldownTracker = {}
 
 local CooldownTracker = QR.CooldownTracker
 
+-- How long a refresh batch may hold remembered cooldowns before it is treated
+-- as abandoned. A 25-quest refresh spends about 0.4s spread across frames.
+local BATCH_MAX_SECONDS = 2
+
 -------------------------------------------------------------------------------
 -- Visible inventory/map views share one event observer and expiry timer.
 -------------------------------------------------------------------------------
@@ -269,6 +273,7 @@ end
 -- from stale memory. Opening always starts from an empty memo.
 function CooldownTracker:BeginBatch()
     self.batchOpen = true
+    self.batchStamp = GetTime and GetTime() or 0
     if self.batchMemo then wipe(self.batchMemo) end
 end
 
@@ -281,6 +286,16 @@ function CooldownTracker:EndBatch()
 end
 
 function CooldownTracker:GetCooldown(id, sourceType)
+    -- A batch is closed on every path that leaves a refresh, but the tail of
+    -- that refresh is not all inside a pcall: an error there would leave one
+    -- open, and every panel and filter in the addon reads through here. The
+    -- stamp bounds that to BATCH_MAX_SECONDS rather than to the next refresh.
+    -- It is a backstop, not the scope -- the scope is the batch.
+    if self.batchOpen and self.batchStamp
+        and (GetTime and GetTime() or 0) - self.batchStamp > BATCH_MAX_SECONDS then
+        self:EndBatch()
+    end
+
     local memo, key
     if self.batchOpen then
         memo = self.batchMemo

--- a/QuickRoute/Modules/CooldownTracker.lua
+++ b/QuickRoute/Modules/CooldownTracker.lua
@@ -252,15 +252,66 @@ end
 -- @param id number The item or spell ID
 -- @param sourceType string "item", "toy", "spell", or "equipped"
 -- @return table {ready=bool, remaining=seconds, start=number, duration=number}
+--- Reuse client answers about cooldowns until EndBatch.
+-- A refresh computes one route per tracked quest, each on its own frame, and
+-- every route prices every teleport it could take: measured at 2300 cooldown
+-- queries for 92 distinct teleports in a single refresh of 25 quests. Inside a
+-- batch that is the same question asked over and over within a fraction of a
+-- second, so the first answer stands for all of them.
+--
+-- Scoped to a batch rather than to wall time on purpose. This is live state:
+-- outside a batch every caller -- the panels, the filters, the readiness check
+-- that decides whether a cooldown moved -- reads the client, and a memo with a
+-- timer instead of a scope would answer them with its own last word and hide
+-- the very change they exist to notice.
+-- Opening is idempotent rather than counted: one refresh batch runs at a time,
+-- and a batch left open by a cancelled refresh would otherwise go on answering
+-- from stale memory. Opening always starts from an empty memo.
+function CooldownTracker:BeginBatch()
+    self.batchOpen = true
+    if self.batchMemo then wipe(self.batchMemo) end
+end
+
+--- End the batch opened by BeginBatch and drop what it remembered.
+-- Safe to call when no batch is open, so a cancelled refresh can call it
+-- unconditionally.
+function CooldownTracker:EndBatch()
+    self.batchOpen = false
+    if self.batchMemo then wipe(self.batchMemo) end
+end
+
 function CooldownTracker:GetCooldown(id, sourceType)
+    local memo, key
+    if self.batchOpen then
+        memo = self.batchMemo
+        if not memo then memo = {}; self.batchMemo = memo end
+        key = (sourceType or "item") .. ":" .. tostring(id)
+        local entry = memo[key]
+        if entry then return entry end
+    end
+
+    local result
     if sourceType == "spell" then
-        return self:GetSpellCooldown(id)
+        result = self:GetSpellCooldown(id)
     elseif sourceType == "toy" then
-        return self:GetToyCooldown(id)
+        result = self:GetToyCooldown(id)
     else
         -- "item" or "equipped" both use item cooldown
-        return self:GetItemCooldown(id)
+        result = self:GetItemCooldown(id)
     end
+
+    if not memo then return result end
+    -- A copy, never the shared result table the queries above return: those are
+    -- overwritten by the next query, so a memo of references would answer every
+    -- id with whatever was asked last.
+    local entry = {
+        ready = result.ready,
+        remaining = result.remaining,
+        start = result.start,
+        duration = result.duration,
+    }
+    memo[key] = entry
+    return entry
 end
 
 --- Check if a teleport is ready (off cooldown)

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -643,6 +643,10 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- Preserve capability/equipment invalidation even when this event joins a
     -- pending BAG_UPDATE batch (e.g. looting and learning a riding spell).
     if event ~= "BAG_UPDATE" then forceGraphRefresh = true end
+    -- A learned or unlearned spell is the only thing that changes a cast time.
+    if event == "SPELLS_CHANGED" and QR.TravelTime then
+        QR.TravelTime.castTimeBySpell = nil
+    end
 
     -- A deferred scan is normally run by the leave-combat callback. If that
     -- never arrives -- a reload or a logout while fighting ends the fight

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -41,7 +41,12 @@ local QTB = QR.QuestTeleportButtons
 -- it half way: a batch left open would keep answering later callers -- the
 -- panels, the filters, the readiness check -- from memory, and cooldowns are
 -- live state.
-local function EndCooldownBatch()
+local function EndCooldownBatch(generation)
+    -- A refresh that has been superseded still gets one more frame, and it must
+    -- not close the batch its successor just opened. Callers inside a refresh
+    -- pass their generation; callers that mean "close whatever is open" -- the
+    -- readiness check, CancelRefresh -- pass nothing.
+    if generation and generation ~= QTB._refreshGeneration then return end
     if QR.CooldownTracker and QR.CooldownTracker.EndBatch then
         QR.CooldownTracker:EndBatch()
     end
@@ -119,13 +124,19 @@ end
 --- Offer only an immediately usable first step of the computed quest route.
 -- A teleport on the same continent is not necessarily faster than walking,
 -- and a teleport later in the route must not skip its preceding travel.
-local function FindBestTeleportForQuest(questID)
+--- Where this quest currently points. Resolved through WaypointIntegration's
+-- own 30-second coordinate cache, so asking on every read is cheap.
+local function ResolveQuestWaypoint(questID)
+    if not QR.WaypointIntegration then return nil end
+    local button = QTB.activeButtons[questID]
+    local retry = button and button._pendingSince ~= nil
+    return QR.WaypointIntegration:GetQuestWaypoint(questID, retry)
+end
+
+local function FindBestTeleportForQuest(questID, waypoint)
     if not (QR.WaypointIntegration and QR.PathCalculator and QR.PlayerInventory) then
         return nil, nil, true
     end
-    local button = QTB.activeButtons[questID]
-    local retry = button and button._pendingSince ~= nil
-    local waypoint = QR.WaypointIntegration:GetQuestWaypoint(questID, retry)
     if not waypoint then return nil, nil, true end
 
     local route = QR.PathCalculator:CalculatePath(waypoint.mapID, waypoint.x, waypoint.y, waypoint.title)
@@ -158,8 +169,22 @@ local function GetCachedTeleportForQuest(questID)
     if not position then QTB.questCache[questID] = nil; return nil, nil, nil, true end
     local cached = QTB.questCache[questID]
     local calculator = QR.PathCalculator
+
+    -- Where the quest points is part of the key. Completing an objective can
+    -- advance a quest to one on another continent without the player moving a
+    -- step, and every other field of this key would still match -- the cached
+    -- entry would go on offering a teleport to where the quest used to be.
+    --
+    -- The map, not the coordinates: GetNextWaypoint walks a multi-step quest
+    -- along its path, so x and y drift while the destination stays put, and
+    -- comparing them would recompute a route that cannot have changed. Which
+    -- zone the player is being sent to is what decides the first step.
+    local waypoint = ResolveQuestWaypoint(questID)
+    local destMapID = waypoint and waypoint.mapID
+
     if cached and not (QTB.flightChoices and QTB.flightChoices[questID])
         and cached.position == position and cached.graph == (calculator and calculator.graph)
+        and cached.destMapID == destMapID
         and not (calculator and calculator.graphDirty) and (now - cached.time) < CACHE_TTL then
         local cooldown = cached.teleportID and QR.CooldownTracker
             and QR.CooldownTracker:GetCooldown(cached.teleportID, cached.sourceType)
@@ -169,7 +194,7 @@ local function GetCachedTeleportForQuest(questID)
     end
 
     local generation = QTB._refreshGeneration
-    local teleportID, entry, incomplete, direct = FindBestTeleportForQuest(questID)
+    local teleportID, entry, incomplete, direct = FindBestTeleportForQuest(questID, waypoint)
     -- Reentrant invalidation cancels this result as well as its UI callback.
     -- Never refill the cache with a route from the cancelled calculation.
     if generation ~= QTB._refreshGeneration then return nil, nil, nil, true end
@@ -186,12 +211,14 @@ local function GetCachedTeleportForQuest(questID)
             data = entry.data,
             time = now,
             position = position,
+            destMapID = destMapID,
             graph = QR.PathCalculator and QR.PathCalculator.graph,
         }
         return teleportID, entry.sourceType, entry.data
     end
 
-    QTB.questCache[questID] = { time = now, position = position, graph = QR.PathCalculator and QR.PathCalculator.graph, direct = direct }
+    QTB.questCache[questID] = { time = now, position = position, destMapID = destMapID,
+        graph = QR.PathCalculator and QR.PathCalculator.graph, direct = direct }
     return nil, nil, nil, nil, direct
 end
 
@@ -225,6 +252,13 @@ end
 -- SPELL_UPDATE_COOLDOWN also fires for unrelated abilities and global
 -- cooldown updates. Replan quests only when a teleport's readiness changes.
 local function UpdateCooldownState()
+    -- This is the check that decides whether a cooldown moved, so it has to see
+    -- the client and not a batch's remembered answers -- CooldownTracker's own
+    -- comment says as much. A refresh batch spans a frame per tracked quest, so
+    -- one can still be open when SPELL_UPDATE_COOLDOWN arrives; reading its
+    -- memo here would report "nothing changed" for the very teleport the player
+    -- just used, and the rest of the batch would hand out a button for it.
+    EndCooldownBatch()
     local previous = QTB.cooldownState or {}
     local current, changed = {}, false
     local teleports = QR.PlayerInventory and QR.PlayerInventory:GetAllTeleports() or {}
@@ -537,13 +571,13 @@ function QTB:RefreshButtons()
         return generation == QTB._refreshGeneration and QTB.initialized and QTB.enabled and not InCombatLockdown()
     end
     local function RefreshOne()
-        if not IsCurrent() then EndCooldownBatch(); return end
+        if not IsCurrent() then EndCooldownBatch(generation); return end
         local questID = trackedQuests[index]
-        if not questID or activeCount >= POOL_SIZE then EndCooldownBatch(); return end
+        if not questID or activeCount >= POOL_SIZE then EndCooldownBatch(generation); return end
         -- A route calculation can take several milliseconds. Never calculate
         -- every watched quest in the same quest-log/event frame.
         local ok, teleportID, sourceType, data, incomplete, direct = pcall(GetCachedTeleportForQuest, questID)
-        if not IsCurrent() then EndCooldownBatch(); return end
+        if not IsCurrent() then EndCooldownBatch(generation); return end
         if not ok then
             QR:Debug("Quest button route unavailable: " .. tostring(teleportID))
             teleportID = nil
@@ -621,7 +655,7 @@ function QTB:RefreshButtons()
             end
             if not next(QTB.activeButtons) and QTB.updateFrame then QTB.updateFrame:Hide() end
             QTB._refreshRunning = false
-            EndCooldownBatch()
+            EndCooldownBatch(generation)
             QTB._lastRefreshGraph = QR.PathCalculator and QR.PathCalculator.graph
         end
     end

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -36,21 +36,34 @@ QR.QuestTeleportButtons = {
 
 local QTB = QR.QuestTeleportButtons
 
--- Events after which a cached route may be wrong in a way no field of the cache
--- key can show. Both change which quests exist to route to, and a stale entry
--- would then belong to a quest that is no longer tracked. SPELL_UPDATE_COOLDOWN
--- joins them only once UpdateCooldownState has confirmed a cooldown really
--- moved: a teleport coming off cooldown can beat the one a cached entry chose,
--- and the read path only re-checks the cooldown of the teleport already cached.
+-- The one event after which a cached route may be wrong in a way no field of
+-- the cache key can show: a teleport coming off cooldown can beat the one a
+-- cached entry chose, and the read path only re-checks the cooldown of the
+-- teleport already cached. SPELL_UPDATE_COOLDOWN reaches this table only once
+-- UpdateCooldownState has confirmed a readiness really moved.
 --
--- SPELLS_CHANGED and BAG_UPDATE_DELAYED are deliberately absent. A teleport
--- appearing or disappearing reaches the graph through PlayerInventory's rescan,
--- which builds a new graph, and every cached entry records the graph it was
--- computed against -- so those invalidate themselves, without paying for the
--- far more common firings that change no teleport at all.
+-- Every other event this module listens to is deliberately absent.
+--
+-- SUPER_TRACKING_CHANGED changes which quest carries the arrow, not what any
+-- quest's route is: WaypointIntegration:GetQuestWaypoint takes an explicit
+-- questID and never consults C_SuperTrack. Measured with 25 tracked quests, a
+-- firing re-computed all 25 routes and none of the 25 values differed, at 62 ms
+-- for a character with a full teleport collection. It fires on every quest
+-- turn-in and accept, whenever an objective auto-advances the arrow, on any
+-- click in the tracker or on the map, and whenever another addon calls
+-- C_SuperTrack.SetSuperTrackedQuestID. WaypointIntegration says the same of its
+-- own cache one file over: "per-questID entries are already keyed correctly".
+--
+-- QUEST_WATCH_LIST_CHANGED does change the watched set, but only for the quest
+-- added or removed. Every refresh ends in PruneQuestCache(watched), which drops
+-- exactly the entries no longer watched, and a newly watched quest has no entry
+-- to be stale. Wiping the other 24 measured 50 ms and changed nothing.
+--
+-- SPELLS_CHANGED and BAG_UPDATE_DELAYED: a teleport appearing or disappearing
+-- reaches the graph through PlayerInventory's rescan, which builds a new graph,
+-- and every cached entry records the graph it was computed against -- so those
+-- invalidate themselves.
 local INVALIDATING_EVENTS = {
-    QUEST_WATCH_LIST_CHANGED = true,
-    SUPER_TRACKING_CHANGED = true,
     SPELL_UPDATE_COOLDOWN = true,
 }
 
@@ -780,27 +793,22 @@ function QTB:RegisterEvents()
         -- Quest targets can change during combat or while this feature is
         -- disabled. Invalidate Lua state now; defer all button work.
         if InCombatLockdown() then
-            -- Which quests are tracked can change mid-fight, and a route cached
-            -- for a quest that is no longer tracked is wrong in a way no field
-            -- of the cache key can show. Everything else keeps its cache:
-            -- emptying it here does not save a frame during the fight, it moves
-            -- a full recompute of every tracked quest to the moment the fight
-            -- ends, on top of the scan and the graph rebuild that land there.
-            -- SPELL_UPDATE_COOLDOWN stays out of it because confirming one
-            -- means walking the teleport list, which is the work combat is
-            -- meant to avoid; the first firing after the fight settles it.
-            if event == "QUEST_WATCH_LIST_CHANGED" or event == "SUPER_TRACKING_CHANGED" then
-                QTB:InvalidateCache()
-            else
-                QTB:CancelRefresh()
-            end
+            -- Nothing is read from the cache during a fight and no button work
+            -- runs, so there is nothing to keep fresh; emptying it here would
+            -- only move a full recompute of every tracked quest to the moment
+            -- the fight ends, on top of the inventory scan and graph rebuild
+            -- that land there. A quest untracked mid-fight is dropped by the
+            -- PruneQuestCache at the end of the first refresh afterwards, and a
+            -- newly tracked one has no entry to be stale.
+            QTB:CancelRefresh()
             return
         end
         if not QTB.enabled then QTB:InvalidateCache(); return end
         if event == "SPELL_UPDATE_COOLDOWN" and not UpdateCooldownState() then return end
 
-        -- Only the events that change WHICH quests are tracked empty the cache.
-        -- Everything a cached entry depends on besides that -- the player's
+        -- Only a confirmed cooldown change empties the cache; see
+        -- INVALIDATING_EVENTS above for why nothing else has to.
+        -- Everything a cached entry depends on -- the player's
         -- position bucket, the graph it was computed against, whether the graph
         -- is dirty, the entry's age, and the teleport's cooldown -- is checked
         -- on every read, so a wholesale wipe here adds no freshness. It did

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -367,6 +367,9 @@ local function ReleaseButton(btn)
     btn._pendingTeleportID, btn._pendingSourceType = nil, nil
     btn.inUse = false
     btn.questID = nil
+    -- The next quest to use this button must be positioned, not assumed to be
+    -- where the last one was.
+    btn._lastX, btn._lastY, btn._lastScale = nil, nil, nil
     btn.tooltipText = nil
     btn.tooltipSubtext = nil
     if btn.icon then
@@ -660,19 +663,33 @@ end
 --   that raised -- in both cases the block set is incomplete and the caller
 --   must not conclude a quest's block is gone. One provider failing is enough:
 --   its blocks are missing from an otherwise plausible-looking result.
+-- Reused across calls. This runs five times a second for as long as a quest
+-- teleport button is on screen, and two fresh tables plus two closures per call
+-- measured 2.9 KiB each time -- around 50 MiB an hour of standing still. The
+-- returned table is only read before the next call, which is the same contract
+-- CooldownTracker's result tables carry.
+local collectedBlocks = {}
+local collectedQuestTagged = {}
+
 function QTB:CollectQuestBlocks()
-    local blocks = {}
-    local questTagged = {}
+    local blocks = collectedBlocks
+    local questTagged = collectedQuestTagged
+    wipe(blocks)
+    wipe(questTagged)
     local recognised = false
     local failed = false
 
-    local function record(id, block, isQuestModule)
-        if type(id) == "number" and not (issecretvalue and issecretvalue(id))
-            and type(block) == "table" and block.HeaderText
-            and (isQuestModule or not questTagged[id]) then
-            blocks[id] = block
-            questTagged[id] = isQuestModule
+    local record = self._recordQuestBlock
+    if not record then
+        record = function(id, block, isQuestModule)
+            if type(id) == "number" and not (issecretvalue and issecretvalue(id))
+                and type(block) == "table" and block.HeaderText
+                and (isQuestModule or not questTagged[id]) then
+                blocks[id] = block
+                questTagged[id] = isQuestModule
+            end
         end
+        self._recordQuestBlock = record
     end
 
     local modules = ObjectiveTrackerFrame and
@@ -753,6 +770,12 @@ function QTB:OnUpdate(elapsed)
 
     if InCombatLockdown() then return end
 
+    -- Nothing to position. The frame is hidden when the last button goes, so
+    -- this is belt and braces -- but walking the tracker's whole module tree
+    -- five times a second to place no buttons is the one case worth spelling
+    -- out.
+    if not next(self.activeButtons) then return end
+
     -- No ObjectiveTrackerFrame in test environment or if hidden
     if not ObjectiveTrackerFrame then
         return
@@ -777,9 +800,18 @@ function QTB:OnUpdate(elapsed)
             local bottom = block:GetBottom()
             if left and top and bottom then
                 local centerY = (top + bottom) / 2
-                btn:SetScale(block:GetEffectiveScale() / UIParent:GetEffectiveScale())
-                btn:ClearAllPoints()
-                btn:SetPoint("RIGHT", UIParent, "BOTTOMLEFT", left + BUTTON_OFFSET_X, centerY)
+                local anchorX = left + BUTTON_OFFSET_X
+                local scale = block:GetEffectiveScale() / UIParent:GetEffectiveScale()
+                -- Re-anchoring invalidates the frame's layout, so it is done
+                -- only when the block actually moved. The tracker is static
+                -- most of the time, and this runs five times a second.
+                -- SecureButtons' overlay loop guards the same way.
+                if btn._lastX ~= anchorX or btn._lastY ~= centerY or btn._lastScale ~= scale then
+                    btn:SetScale(scale)
+                    btn:ClearAllPoints()
+                    btn:SetPoint("RIGHT", UIParent, "BOTTOMLEFT", anchorX, centerY)
+                    btn._lastX, btn._lastY, btn._lastScale = anchorX, centerY, scale
+                end
                 if not btn:IsShown() then
                     btn:Show()
                 end

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -36,6 +36,17 @@ QR.QuestTeleportButtons = {
 
 local QTB = QR.QuestTeleportButtons
 
+--- Drop the cooldown answers remembered for one refresh batch.
+-- Called from every path that leaves a batch, including the ones that abandon
+-- it half way: a batch left open would keep answering later callers -- the
+-- panels, the filters, the readiness check -- from memory, and cooldowns are
+-- live state.
+local function EndCooldownBatch()
+    if QR.CooldownTracker and QR.CooldownTracker.EndBatch then
+        QR.CooldownTracker:EndBatch()
+    end
+end
+
 -- The one event after which a cached route may be wrong in a way no field of
 -- the cache key can show: a teleport coming off cooldown can beat the one a
 -- cached entry chose, and the read path only re-checks the cooldown of the
@@ -194,6 +205,7 @@ end
 function QTB:CancelRefresh()
     self._refreshGeneration = (self._refreshGeneration or 0) + 1
     self._refreshRunning = false
+    EndCooldownBatch()
 end
 
 -- TTL must release entries, not just stop reusing them. Lower-priority quests
@@ -512,17 +524,23 @@ function QTB:RefreshButtons()
     local index, activeCount, retained = 1, 0, {}
     self._pendingRefreshAt = nil
     self._refreshRunning = true
+    -- Every route in this batch prices every teleport against its cooldown, and
+    -- the batch runs one route per frame, so the same question reaches the
+    -- client once per tracked quest. One answer serves the batch.
+    if QR.CooldownTracker and QR.CooldownTracker.BeginBatch then
+        QR.CooldownTracker:BeginBatch()
+    end
     local function IsCurrent()
         return generation == QTB._refreshGeneration and QTB.initialized and QTB.enabled and not InCombatLockdown()
     end
     local function RefreshOne()
-        if not IsCurrent() then return end
+        if not IsCurrent() then EndCooldownBatch(); return end
         local questID = trackedQuests[index]
-        if not questID or activeCount >= POOL_SIZE then return end
+        if not questID or activeCount >= POOL_SIZE then EndCooldownBatch(); return end
         -- A route calculation can take several milliseconds. Never calculate
         -- every watched quest in the same quest-log/event frame.
         local ok, teleportID, sourceType, data, incomplete, direct = pcall(GetCachedTeleportForQuest, questID)
-        if not IsCurrent() then return end
+        if not IsCurrent() then EndCooldownBatch(); return end
         if not ok then
             QR:Debug("Quest button route unavailable: " .. tostring(teleportID))
             teleportID = nil
@@ -600,6 +618,7 @@ function QTB:RefreshButtons()
             end
             if not next(QTB.activeButtons) and QTB.updateFrame then QTB.updateFrame:Hide() end
             QTB._refreshRunning = false
+            EndCooldownBatch()
             QTB._lastRefreshGraph = QR.PathCalculator and QR.PathCalculator.graph
         end
     end

--- a/QuickRoute/Modules/WaypointIntegration.lua
+++ b/QuickRoute/Modules/WaypointIntegration.lua
@@ -242,7 +242,12 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                 mapID = cached.mapID,
                 x = cached.x,
                 y = cached.y,
-                title = cached.title or QR.L["SOURCE_QUEST"],
+                -- Asked for again when the entry has none: quest data streams
+                -- in after login, so an early miss would otherwise freeze
+                -- "Quest Objective" into the entry for the next 30 seconds.
+                title = cached.title
+                    or (C_QuestLog.GetTitleForQuestID and C_QuestLog.GetTitleForQuestID(questID))
+                    or QR.L["SOURCE_QUEST"],
             }
         elseif not ignoreNegativeCache then
             -- Cached "not found" result — skip for dropdown queries which retry
@@ -256,7 +261,9 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
     -- Every entry carries the title it was resolved with, so a later hit does
     -- not have to ask the client for it again.
     local function RememberQuestCoordinates(entry)
-        entry.title = questTitle
+        -- Only a real title is kept. The fallback means the client has not
+        -- loaded this quest yet, and remembering it would outlive the reason.
+        if questTitle ~= QR.L["SOURCE_QUEST"] then entry.title = questTitle end
         CacheQuestCoordinates(questID, entry)
     end
 

--- a/QuickRoute/Modules/WaypointIntegration.lua
+++ b/QuickRoute/Modules/WaypointIntegration.lua
@@ -228,9 +228,11 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
         return nil
     end
 
-    local questTitle = C_QuestLog.GetTitleForQuestID and C_QuestLog.GetTitleForQuestID(questID) or QR.L["SOURCE_QUEST"]
-
-    -- Check quest coordinate cache
+    -- Check quest coordinate cache. The title is asked for after the cache is
+    -- consulted, and remembered with the entry: a hit is by far the common case
+    -- -- the cache serves most of the refreshes in a minute of walking -- and
+    -- asking the client for a title it already answered was measured at 925
+    -- calls a minute for 25 quests.
     local now = GetTime()
     local cached = questCoordCache[questID]
     if cached and (now - cached.time) < QUEST_COORD_CACHE_TTL then
@@ -240,13 +242,22 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                 mapID = cached.mapID,
                 x = cached.x,
                 y = cached.y,
-                title = questTitle,
+                title = cached.title or QR.L["SOURCE_QUEST"],
             }
         elseif not ignoreNegativeCache then
             -- Cached "not found" result — skip for dropdown queries which retry
             QR:Debug(string_format("Quest %d: negative cache hit (no coords found previously)", questID))
             return nil
         end
+    end
+
+    local questTitle = C_QuestLog.GetTitleForQuestID and C_QuestLog.GetTitleForQuestID(questID) or QR.L["SOURCE_QUEST"]
+
+    -- Every entry carries the title it was resolved with, so a later hit does
+    -- not have to ask the client for it again.
+    local function RememberQuestCoordinates(entry)
+        entry.title = questTitle
+        CacheQuestCoordinates(questID, entry)
     end
 
     -- Build transit hub set from PortalHubs (cities that are routing intermediaries)
@@ -309,7 +320,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                         -- Check portal-through before returning
                                         local throughMapID, throughX, throughY = CheckPortalThroughZone(questID, childInfo.mapID)
                                         if throughMapID then
-                                            CacheQuestCoordinates(questID, { mapID = throughMapID, x = throughX, y = throughY, time = now })
+                                            RememberQuestCoordinates({ mapID = throughMapID, x = throughX, y = throughY, time = now })
                                             return {
                                                 mapID = throughMapID,
                                                 x = throughX,
@@ -317,7 +328,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                                 title = questTitle,
                                             }
                                         end
-                                        CacheQuestCoordinates(questID, { mapID = childInfo.mapID, x = zoneX, y = zoneY, time = now })
+                                        RememberQuestCoordinates({ mapID = childInfo.mapID, x = zoneX, y = zoneY, time = now })
                                         return {
                                             mapID = childInfo.mapID,
                                             x = zoneX,
@@ -346,7 +357,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                     -- Check if quest has objectives beyond a portal from this zone
                     local throughMapID, throughX, throughY = CheckPortalThroughZone(questID, wpMapID)
                     if throughMapID then
-                        CacheQuestCoordinates(questID, { mapID = throughMapID, x = throughX, y = throughY, time = now })
+                        RememberQuestCoordinates({ mapID = throughMapID, x = throughX, y = throughY, time = now })
                         return {
                             mapID = throughMapID,
                             x = throughX,
@@ -354,7 +365,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                             title = questTitle,
                         }
                     end
-                    CacheQuestCoordinates(questID, { mapID = wpMapID, x = wpX, y = wpY, time = now })
+                    RememberQuestCoordinates({ mapID = wpMapID, x = wpX, y = wpY, time = now })
                     return {
                         mapID = wpMapID,
                         x = wpX,
@@ -378,7 +389,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
             -- Check if quest has objectives beyond a portal from this zone
             local throughMapID, throughX, throughY = CheckPortalThroughZone(questID, playerMapID)
             if throughMapID then
-                CacheQuestCoordinates(questID, { mapID = throughMapID, x = throughX, y = throughY, time = now })
+                RememberQuestCoordinates({ mapID = throughMapID, x = throughX, y = throughY, time = now })
                 return {
                     mapID = throughMapID,
                     x = throughX,
@@ -386,7 +397,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                     title = questTitle,
                 }
             end
-            CacheQuestCoordinates(questID, { mapID = playerMapID, x = wpX, y = wpY, time = now })
+            RememberQuestCoordinates({ mapID = playerMapID, x = wpX, y = wpY, time = now })
             return {
                 mapID = playerMapID,
                 x = wpX,
@@ -417,7 +428,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                     local qx, qy = questInfo.x, questInfo.y
                     if qx and qy and (qx ~= 0 or qy ~= 0) and not (transitFallback and transitHubMapIDs[playerMapID]) then
                         QR:Debug(string_format("Quest %d: GetQuestsOnMap -> (%.4f, %.4f)", questID, qx, qy))
-                        CacheQuestCoordinates(questID, { mapID = playerMapID, x = qx, y = qy, time = now })
+                        RememberQuestCoordinates({ mapID = playerMapID, x = qx, y = qy, time = now })
                         return {
                             mapID = playerMapID,
                             x = qx,
@@ -448,7 +459,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                     local qx, qy = questInfo.x, questInfo.y
                                     if qx and qy and (qx ~= 0 or qy ~= 0) then
                                         QR:Debug(string_format("Quest %d: Broad GetQuestsOnMap found objective on map %d (%.4f, %.4f)", questID, zoneID, qx, qy))
-                                        CacheQuestCoordinates(questID, { mapID = zoneID, x = qx, y = qy, time = now })
+                                        RememberQuestCoordinates({ mapID = zoneID, x = qx, y = qy, time = now })
                                         return {
                                             mapID = zoneID,
                                             x = qx,
@@ -486,7 +497,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                         if continent then
                                             QR:Debug(string_format("Quest %d: Dynamic scan found routable objective on map %d (%s) (%.4f, %.4f)",
                                                 questID, childMapID, childInfo.name or "?", qx, qy))
-                                            CacheQuestCoordinates(questID, { mapID = childMapID, x = qx, y = qy, time = now })
+                                            RememberQuestCoordinates({ mapID = childMapID, x = qx, y = qy, time = now })
                                             return {
                                                 mapID = childMapID,
                                                 x = qx,
@@ -512,7 +523,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
         local tqX, tqY = C_TaskQuest.GetQuestLocation(questID, playerMapID)
         if tqX and tqY and (tqX ~= 0 or tqY ~= 0) and not (transitFallback and transitHubMapIDs[playerMapID]) then
             QR:Debug(string_format("Quest %d: TaskQuest.GetQuestLocation -> (%.4f, %.4f)", questID, tqX, tqY))
-            CacheQuestCoordinates(questID, { mapID = playerMapID, x = tqX, y = tqY, time = now })
+            RememberQuestCoordinates({ mapID = playerMapID, x = tqX, y = tqY, time = now })
             return {
                 mapID = playerMapID,
                 x = tqX,
@@ -533,7 +544,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                     local wpX, wpY = C_QuestLog.GetNextWaypointForMap(questID, zoneID)
                     if wpX and wpY and not transitHubMapIDs[zoneID] then
                         QR:Debug(string_format("Quest %d: Broad scan found on map %d (%.4f, %.4f)", questID, zoneID, wpX, wpY))
-                        CacheQuestCoordinates(questID, { mapID = zoneID, x = wpX, y = wpY, time = now })
+                        RememberQuestCoordinates({ mapID = zoneID, x = wpX, y = wpY, time = now })
                         return {
                             mapID = zoneID,
                             x = wpX,
@@ -577,7 +588,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                     if qx and qy and (qx ~= 0 or qy ~= 0) then
                                         QR:Debug(string_format("Quest %d: header %q -> zone %d, GetQuestsOnMap (%.4f, %.4f)",
                                             questID, questHeader, zoneID, qx, qy))
-                                        CacheQuestCoordinates(questID, { mapID = zoneID, x = qx, y = qy, time = now })
+                                        RememberQuestCoordinates({ mapID = zoneID, x = qx, y = qy, time = now })
                                         return {
                                             mapID = zoneID,
                                             x = qx,
@@ -635,7 +646,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                     if entrances and #entrances == 1 then
                         local entrance = entrances[1]
                         if playerInstanceID and entrance.journalInstanceID == playerInstanceID then
-                            CacheQuestCoordinates(questID, { time = now })
+                            RememberQuestCoordinates({ time = now })
                             return nil
                         end
                         local ex, ey
@@ -650,7 +661,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                         if ex and ey then
                             QR:Debug(string_format("Quest %d: Entrance %q at map %d (%.4f, %.4f)",
                                 questID, entrance.name or "?", highlightMapID, ex, ey))
-                            CacheQuestCoordinates(questID, { mapID = highlightMapID, x = ex, y = ey, time = now })
+                            RememberQuestCoordinates({ mapID = highlightMapID, x = ex, y = ey, time = now })
                             return {
                                 mapID = highlightMapID,
                                 x = ex,
@@ -668,10 +679,10 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
             for instanceID, inst in pairs(QR.DungeonData.instances) do
                 if inst.name and inst.zoneMapID and inst.x and inst.y then
                     if string_lower(inst.name) == string_lower(questHeader) then
-                        if playerInstanceID == instanceID then CacheQuestCoordinates(questID, { time = now }); return nil end
+                        if playerInstanceID == instanceID then RememberQuestCoordinates({ time = now }); return nil end
                         QR:Debug(string_format("Quest %d: header matches dungeon %q (instance %d) at map %d",
                             questID, inst.name, instanceID, inst.zoneMapID))
-                        CacheQuestCoordinates(questID, { mapID = inst.zoneMapID, x = inst.x, y = inst.y, time = now })
+                        RememberQuestCoordinates({ mapID = inst.zoneMapID, x = inst.x, y = inst.y, time = now })
                         return {
                             mapID = inst.zoneMapID,
                             x = inst.x,
@@ -694,10 +705,10 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                 for instanceID, inst in pairs(QR.DungeonData.instances) do
                     if inst.name and inst.zoneMapID and inst.x and inst.y then
                         if string_lower(inst.name) == string_lower(titlePrefix) then
-                            if playerInstanceID == instanceID then CacheQuestCoordinates(questID, { time = now }); return nil end
+                            if playerInstanceID == instanceID then RememberQuestCoordinates({ time = now }); return nil end
                             QR:Debug(string_format("Quest %d: title prefix matches dungeon %q (instance %d) at map %d",
                                 questID, inst.name, instanceID, inst.zoneMapID))
-                            CacheQuestCoordinates(questID, { mapID = inst.zoneMapID, x = inst.x, y = inst.y, time = now })
+                            RememberQuestCoordinates({ mapID = inst.zoneMapID, x = inst.x, y = inst.y, time = now })
                             return {
                                 mapID = inst.zoneMapID,
                                 x = inst.x,
@@ -730,7 +741,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                 if qx and qy and (qx ~= 0 or qy ~= 0) then
                                     QR:Debug(string_format("Quest %d: broad GetQuestsOnMap found on map %d (%.4f, %.4f)",
                                         questID, zoneID, qx, qy))
-                                    CacheQuestCoordinates(questID, { mapID = zoneID, x = qx, y = qy, time = now })
+                                    RememberQuestCoordinates({ mapID = zoneID, x = qx, y = qy, time = now })
                                     return {
                                         mapID = zoneID,
                                         x = qx,
@@ -762,7 +773,7 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
                                         if continent then
                                             QR:Debug(string_format("Quest %d: dynamic scan found on routable map %d (%s) (%.4f, %.4f)",
                                                 questID, childMapID, childInfo.name or "?", qx, qy))
-                                            CacheQuestCoordinates(questID, { mapID = childMapID, x = qx, y = qy, time = now })
+                                            RememberQuestCoordinates({ mapID = childMapID, x = qx, y = qy, time = now })
                                             return {
                                                 mapID = childMapID,
                                                 x = qx,
@@ -787,13 +798,13 @@ function WaypointIntegration:GetQuestWaypoint(questID, ignoreNegativeCache)
     -- transit hub.
     if transitFallback then
         QR:Debug(string_format("Quest %d: no better destination found, using transit hub fallback map %d", questID, transitFallback.mapID))
-        CacheQuestCoordinates(questID, { mapID = transitFallback.mapID, x = transitFallback.x, y = transitFallback.y, time = now })
+        RememberQuestCoordinates({ mapID = transitFallback.mapID, x = transitFallback.x, y = transitFallback.y, time = now })
         return { mapID = transitFallback.mapID, x = transitFallback.x, y = transitFallback.y, title = questTitle }
     end
 
     -- No coordinates found from any API - cache negative result to avoid repeated scans
     QR:Debug(string_format("Quest %d (%s): no coordinates found from any API", questID, questTitle))
-    CacheQuestCoordinates(questID, { time = now })
+    RememberQuestCoordinates({ time = now })
     return nil
 end
 

--- a/tests/test_cooldowntracker.lua
+++ b/tests/test_cooldowntracker.lua
@@ -273,3 +273,85 @@ T:run("GetReadyTeleports: returns empty table when all on cooldown", function(t)
     -- The spell should not be in the ready list
     t:assertNil(ready[53140], "Spell on cooldown not in ready list")
 end)
+
+-------------------------------------------------------------------------------
+-- Batch memo
+-------------------------------------------------------------------------------
+
+--- Count the queries that reach the client, not the wrapper the memo sits in.
+local function withCountedQueries(body)
+    local CT = QR.CooldownTracker
+    local realSpell, realItem = CT.GetSpellCooldown, CT.GetItemCooldown
+    local queries = 0
+    CT.GetSpellCooldown = function(self, ...) queries = queries + 1; return realSpell(self, ...) end
+    CT.GetItemCooldown = function(self, ...) queries = queries + 1; return realItem(self, ...) end
+    local ok, err = pcall(body, function() return queries end, function() queries = 0 end)
+    CT.GetSpellCooldown, CT.GetItemCooldown = realSpell, realItem
+    CT:EndBatch()
+    if not ok then error(err, 0) end
+end
+
+T:run("Cooldown batch: one client query serves the whole batch", function(t)
+    withCountedQueries(function(count, reset)
+        local CT = QR.CooldownTracker
+        CT:EndBatch()
+        reset()
+        for _ = 1, 5 do CT:GetCooldown(3561, "spell") end
+        t:assertEqual(5, count(), "outside a batch every ask reaches the client")
+
+        CT:BeginBatch()
+        reset()
+        for _ = 1, 5 do CT:GetCooldown(3561, "spell") end
+        t:assertEqual(1, count(), "inside a batch the first answer serves the rest")
+        CT:EndBatch()
+    end)
+end)
+
+T:run("Cooldown batch: the memo does not outlive the batch", function(t)
+    withCountedQueries(function(count, reset)
+        local CT = QR.CooldownTracker
+        CT:BeginBatch()
+        CT:GetCooldown(3561, "spell")
+        CT:EndBatch()
+        reset()
+        CT:GetCooldown(3561, "spell")
+        t:assertEqual(1, count(), "after the batch the client is asked again")
+
+        -- A batch abandoned half way must not answer later callers from memory:
+        -- cooldowns are live state and the panels read them between refreshes.
+        CT:BeginBatch()
+        CT:GetCooldown(3561, "spell")
+        CT:BeginBatch() -- a fresh refresh starts without the previous one ending
+        reset()
+        CT:GetCooldown(3561, "spell")
+        t:assertEqual(1, count(), "reopening a batch starts from an empty memo")
+        CT:EndBatch()
+    end)
+end)
+
+T:run("Cooldown batch: entries are copies, not the shared result table", function(t)
+    withCountedQueries(function()
+        local CT = QR.CooldownTracker
+        local savedCooldowns = MockWoW.config.spellCooldowns
+        local savedTime = MockWoW.config.baseTime
+        MockWoW.config.baseTime = 1000010
+        MockWoW.config.spellCooldowns = {
+            [3561] = nil,                                          -- ready
+            [53140] = { start = 1000000, duration = 600, enable = 1 }, -- on cooldown
+        }
+
+        -- Every spell query returns ONE module-level table that the next query
+        -- overwrites, so a memo of references would hand the second spell's
+        -- answer back for the first id.
+        CT:BeginBatch()
+        local ready = CT:GetCooldown(3561, "spell")
+        local onCooldown = CT:GetCooldown(53140, "spell")
+        t:assertTrue(onCooldown.remaining > 0, "the second spell reads as on cooldown")
+        t:assertEqual(0, ready.remaining, "and the first entry still describes the first spell")
+        t:assertTrue(ready ~= onCooldown, "the two ids do not share one table")
+        CT:EndBatch()
+
+        MockWoW.config.spellCooldowns = savedCooldowns
+        MockWoW.config.baseTime = savedTime
+    end)
+end)

--- a/tests/test_questbutton_async.lua
+++ b/tests/test_questbutton_async.lua
@@ -420,7 +420,7 @@ end)
 -- bought no freshness and moved a full recompute of every tracked quest to the
 -- moment the fight ended. What a fight can still change is which quests are
 -- tracked, and that is asserted below.
-T:run("Quest button cache: quest events during combat do no secure work, and only a tracked-set change invalidates", function(t)
+T:run("Quest button cache: quest events during combat do no secure work and keep the cache", function(t)
     withRefresh(function(qtb,state)
         state.watched={10001}
         qtb:RefreshButtons()
@@ -438,7 +438,7 @@ T:run("Quest button cache: quest events during combat do no secure work, and onl
         t:assertEqual(writes,state.writes,"Combat quest events perform no protected attribute writes")
         t:assertEqual(1,state.calls,"Combat quest event schedules no route calculation")
         callback(frame,"QUEST_WATCH_LIST_CHANGED")
-        t:assertNil(qtb.questCache[10001],"A change to which quests are tracked does invalidate, in combat too")
+        t:assertNotNil(qtb.questCache[10001],"A tracked-set change in combat keeps the entries it did not touch; PruneQuestCache drops what is no longer watched at the next refresh")
         t:assertEqual(writes,state.writes,"and still performs no protected attribute writes")
         t:assertEqual(1,state.calls,"and still schedules no route calculation")
         frame:UnregisterAllEvents()

--- a/tests/test_questteleportbuttons.lua
+++ b/tests/test_questteleportbuttons.lua
@@ -571,3 +571,87 @@ T:run("CollectQuestBlocks: a module with neither shape is not a failed provider"
         t:assertTrue(recognised, "and the unrelated module did not spoil it")
     end)
 end)
+
+-------------------------------------------------------------------------------
+-- Button positioning
+-------------------------------------------------------------------------------
+
+--- A tracker block that reports a position and can be moved.
+local function positionedBlock(id, left, top, bottom)
+    return {
+        id = id,
+        HeaderText = { GetText = function() return "Quest " .. id end },
+        IsVisible = function() return true end,
+        GetLeft = function(self) return self.left end,
+        GetTop = function(self) return self.top end,
+        GetBottom = function(self) return self.bottom end,
+        GetEffectiveScale = function() return 1 end,
+        left = left, top = top, bottom = bottom,
+    }
+end
+
+--- Drive QTB:OnUpdate against a tracker holding one block, counting how often
+-- the button is re-anchored. Nothing else in the suite reaches this handler:
+-- the mock has no ObjectiveTrackerFrame, so it returns immediately everywhere
+-- else.
+local function withPositioning(fn)
+    local QTB = QR.QuestTeleportButtons
+    if not QTB.initialized then QTB:Initialize() end
+    local block = positionedBlock(60001, 100, 200, 180)
+    local btn = QTB.pool[1]
+    local savedActive = QTB.activeButtons
+    QTB.activeButtons = { [60001] = btn }
+    local points = 0
+    local realSetPoint = btn.SetPoint
+    btn.SetPoint = function(self, ...) points = points + 1; return realSetPoint(self, ...) end
+
+    withTracker({ modules = { { EnumerateActiveBlocks = function(_, cb) cb(block) end } } }, function()
+        fn(QTB, btn, block, function() return points end)
+    end)
+
+    btn.SetPoint = realSetPoint
+    QTB.activeButtons = savedActive
+    btn._lastX, btn._lastY, btn._lastScale = nil, nil, nil
+end
+
+T:run("Positioning: a block that has not moved is not re-anchored", function(t)
+    withPositioning(function(QTB, btn, block, points)
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        local first = points()
+        t:assertTrue(first > 0, "the first tick anchors the button")
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        t:assertEqual(first, points(), "later ticks over an unmoved block do nothing")
+    end)
+end)
+
+T:run("Positioning: a block that moved is re-anchored", function(t)
+    withPositioning(function(QTB, btn, block, points)
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        local before = points()
+        block.top, block.bottom = 400, 380
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        t:assertTrue(points() > before, "the button follows its block")
+    end)
+end)
+
+T:run("Positioning: a recycled button is anchored for its new quest", function(t)
+    withPositioning(function(QTB, btn, block, points)
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        -- The pool hands this button to another quest, whose block happens to
+        -- sit where the last one did. Releasing has to forget the position, or
+        -- the new owner is never anchored at all.
+        QTB:ReleaseAllButtons()
+        QTB.activeButtons = { [60001] = btn }
+        local before = points()
+        QTB.updateElapsed = 10
+        QTB:OnUpdate(0)
+        t:assertTrue(points() > before, "the button is placed again after being reused")
+    end)
+end)

--- a/tests/test_route_recompute_budget.lua
+++ b/tests/test_route_recompute_budget.lua
@@ -84,6 +84,27 @@ local function routesFor(event)
 end
 
 -------------------------------------------------------------------------------
+-- Freshness: what the cache must never serve
+-------------------------------------------------------------------------------
+
+-- Completing an objective can advance a quest to one in another zone without
+-- the player moving a step. Position, graph and age all still match, so the
+-- destination has to be part of the key -- otherwise the button goes on
+-- offering the teleport for where the quest used to point, and the player is
+-- sent to the wrong place.
+T:run("a quest whose objective moved to another zone is routed again", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        t:assertEqual(0, routesFor("QUEST_LOG_UPDATE"), "nothing changed, nothing recomputed")
+
+        MockWoW.config.questWaypoints[71001] = { mapID = 1670, x = 0.5, y = 0.5 }
+        QR.WaypointIntegration:ClearQuestCoordCache()
+        t:assertEqual(1, routesFor("QUEST_LOG_UPDATE"),
+            "the quest that moved is routed again, and only that one")
+    end)
+end)
+
+-------------------------------------------------------------------------------
 -- Cost while moving
 -------------------------------------------------------------------------------
 

--- a/tests/test_route_recompute_budget.lua
+++ b/tests/test_route_recompute_budget.lua
@@ -131,10 +131,29 @@ T:run("changing zone routes again, even at the same coordinates", function(t)
     end)
 end)
 
-T:run("a change to which quests are tracked routes again", function(t)
+-- A tracked-set change used to empty the cache. Measured with 25 quests, that
+-- re-routed all of them and changed none: only the quest added or removed is
+-- affected, and PruneQuestCache already drops what is no longer watched. These
+-- two pin that outcome instead of the wipe.
+T:run("a newly tracked quest is routed, and only that one", function(t)
     withCountedRoutes(function()
         routesFor("QUEST_LOG_UPDATE")
-        t:assertTrue(routesFor("QUEST_WATCH_LIST_CHANGED") > 0,
-            "the tracked set changed, so a cached route may belong to no quest")
+        local watches = MockWoW.config.questWatches
+        watches[#watches + 1] = 71004
+        MockWoW.config.questWaypoints[71004] = { mapID = 84, x = 0.5, y = 0.5 }
+        MockWoW.config.questTitles[71004] = "Budget quest 71004"
+        t:assertEqual(1, routesFor("QUEST_WATCH_LIST_CHANGED"),
+            "the quest just tracked is routed; the three already cached are reused")
+    end)
+end)
+
+T:run("an untracked quest's cached route is dropped", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        t:assertNotNil(QTB.questCache[71003], "cached while the quest was tracked")
+        local watches = MockWoW.config.questWatches
+        watches[#watches] = nil
+        routesFor("QUEST_WATCH_LIST_CHANGED")
+        t:assertNil(QTB.questCache[71003], "and dropped once it is no longer watched")
     end)
 end)

--- a/tests/test_waypointintegration.lua
+++ b/tests/test_waypointintegration.lua
@@ -1959,3 +1959,28 @@ T:run("Inside-dungeon: unrelated instance does not suppress the quest target ent
     t:assertEqual(634, wp and wp.mapID, "Quest routes to Stormheim rather than stopping inside Stonevault")
     resetState()
 end)
+
+T:run("Quest coordinates: a title that had not loaded yet is not remembered", function(t)
+    local WI = QR.WaypointIntegration
+    local savedTitles = MockWoW.config.questTitles
+    local savedWaypoints = MockWoW.config.questWaypoints
+    local savedGetTitle = _G.C_QuestLog.GetTitleForQuestID
+    -- The client answers nil while quest data is still streaming in after
+    -- login; the mock otherwise synthesises a title from the id.
+    MockWoW.config.questTitles = {}
+    MockWoW.config.questWaypoints = { [77001] = { mapID = 84, x = 0.5, y = 0.5 } }
+    _G.C_QuestLog.GetTitleForQuestID = function(id) return MockWoW.config.questTitles[id] end
+    WI:ClearQuestCoordCache()
+
+    local first = WI:GetQuestWaypoint(77001)
+    t:assertNotNil(first, "the waypoint resolves even without a title")
+    MockWoW.config.questTitles[77001] = "Bring Me A Shrubbery"
+    local second = WI:GetQuestWaypoint(77001)
+    t:assertEqual("Bring Me A Shrubbery", second and second.title,
+        "the title is asked for again once the client has it")
+
+    _G.C_QuestLog.GetTitleForQuestID = savedGetTitle
+    MockWoW.config.questTitles = savedTitles
+    MockWoW.config.questWaypoints = savedWaypoints
+    WI:ClearQuestCoordCache()
+end)


### PR DESCRIPTION
Three reviews of 1.18.2 — CPU hot paths, memory and allocation, and client API call counts — each required to measure rather than infer. This fixes what they found that is both worth fixing and safe to fix, and says plainly what it leaves.

## What was wrong, and what it costs now

**Re-routing every quest when the arrow moves.** `SUPER_TRACKING_CHANGED` emptied the quest route cache, and 1.18.2 recomputed every tracked quest from it. Super-tracking decides which quest carries the arrow, not what any quest's route is — `WaypointIntegration:GetQuestWaypoint` takes an explicit questID and never consults `C_SuperTrack`. Measured with 25 tracked quests: all 25 routes recomputed, none of the 25 values different. It fires on every turn-in and accept, on tracker and map clicks, and whenever another addon calls `SetSuperTrackedQuestID`. `QUEST_WATCH_LIST_CHANGED` wiped the same cache for the one quest that changed, where `PruneQuestCache` already dropped what stopped being watched.

| event, 25 tracked quests | before | after |
|---|---|---|
| `SUPER_TRACKING_CHANGED` | 17.7 ms, 25 routes | 0.09 ms, 0 routes |
| `QUEST_WATCH_LIST_CHANGED` | 18.7 ms, 25 routes | 0.13 ms, 0 routes |

**Cooldowns asked once per route instead of once per refresh.** Every route prices every teleport against its cooldown, and a refresh computes one route per quest on its own frame, so the same question reached the client once per quest: 188 client queries for one refresh of 25 quests on a 52-teleport character, 2300 for 92 teleports on a fuller one. `GetCooldown` now memoizes inside a refresh batch — 188 → 66.

**Answers that cannot change, asked repeatedly.** Zone display names (906 → 443 `GetMapInfo` over ten refreshes), quest titles fetched ahead of the cache that made them unnecessary, and spell cast times re-read per priced teleport. Total client calls over ten refreshes: 11,667 → 10,766.

**Allocation and layout at 5 Hz.** The button positioning handler built two tables and two closures per tick (2.9 KiB, ~50 MiB an hour standing still) and re-anchored every button whether or not its block had moved. Tables and closure reused; re-anchoring happens when the block moves.

## A correctness fix that came out of reviewing this

An adversarial review of the branch found that the route cache key had no field for the quest's **destination**. Completing an objective can advance a quest to one in another zone without the player moving a step, so position, graph and age all still matched and the entry went on offering the teleport for where the quest used to point — a button that teleports to the wrong continent. Removing `SUPER_TRACKING_CHANGED` took away the accident that had been covering this for the super-tracked quest; the other 24 were never covered, because `QUEST_LOG_UPDATE` did not invalidate either. The destination is now part of the key, which closes it for all of them.

Three smaller ones from the same review: the readiness check that consumes `SPELL_UPDATE_COOLDOWN` could read the batch memo it exists to check, and now closes the batch first; ending a batch is generation-aware, so a superseded refresh cannot close its successor's; an abandoned batch expires after two seconds rather than freezing cooldowns addon-wide until the next refresh. A quest title that had not streamed in yet is no longer frozen into the coordinate cache as "Quest Objective".

The readiness-check fix ships without a guard. Two attempts to pin it passed for the wrong reason or could not tell the fixed and unfixed code apart — the reviewer reproduced it by stepping an async batch frame by frame, and the mock runs `C_Timer.After` synchronously. Said plainly rather than dressed up in a test that proves nothing.

## What this deliberately does not do

- **`IsQuestFlaggedCompleted`, 1705 calls for 5 distinct ids.** `TravelRequirements` evaluates access requirements live at search time on purpose; its own comment says so and two tests pin it, including one that an unavailable quest API stays *unknown* rather than becoming a remembered false. A memo trades a documented guarantee for call count. I tried it: four tests failed, correctly.
- **`ReconnectPlayerNode`, ~95 KiB per call, up to 1.26 MiB/s while moving.** The largest remaining allocation source. The CPU review's ablation puts an upper bound of 5–11 % of route time on any fix here, and its first simulated version came out slower. Worth doing on its own, with its own measurements, not folded into this.
- **The multi-stop tour matrix, count² cells at ~386 KiB each** (151 MiB transient at 20 stops). Halving it rests on route symmetry, which is an assumption about the graph rather than a fact I measured.
- **`forceGraphRefresh` on every non-`BAG_UPDATE` inventory event**, still ~141 ms per `SPELLS_CHANGED` on a stocked character. Narrowing it needs a capability signature that cannot miss a newly learned flying skill — riding and flying are spells — which is a `TravelRequirements` change.
- **The teleport panel's duplicate spell lookups** (766 client calls per list rebuild, roughly 2× per row). A window-open cost, and merging name and icon means restructuring row construction.
- **`ZoneSurvey` at its 3000-record cap** (~3 MiB of SavedVariables) is an intentional bound, and the unused node index and `RemoveNode`'s reverse scan measured 3 % and 7.8 % of a route respectively.

Figures in `docs/PERFORMANCE-REVIEW-2026-09-06.md` for the moving benchmark ("226 in both") are superseded by 1.18.2 and again here; that document is left as the dated record it is.

## Tests

16,072 → 16,080 assertions, 0 failures, both orders; luacheck clean. Every guard was watched to fail with its fix reverted.

Two gaps the reviews exposed are now covered rather than argued about. The positioning handler had no test at all — the mock ships no `ObjectiveTrackerFrame`, so `OnUpdate` returned immediately in every existing assertion — and now has three, including the recycled-button case that catches a stale remembered anchor. The cooldown memo has one for the aliasing trap: these queries return module-level tables that the next query overwrites, so a memo of references answers every id with whatever was asked last. The test as first written compared a spell against an item, which are different tables even with the bug; it compares two spells now and fails when the memo stores references.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
