### PR TITLE
fix: stop rebuilding the whole travel graph on every SPELLS_CHANGED

### DIFF
--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -598,8 +598,13 @@ eventFrame:RegisterEvent("SKILL_LINES_CHANGED")
 function PlayerInventory:RunDeferredScan()
     PlayerInventory.pendingScan = false
     PlayerInventory.scanDeferredByCombat = false
-    local force = forceGraphRefresh
+    -- What the graph was built against, besides the teleports themselves. A
+    -- change here has to rebuild; an unchanged signature means the comparison
+    -- below is the whole story.
+    local capabilities = QR.PlayerInfo and QR.PlayerInfo:CapabilitySignature()
+    local force = forceGraphRefresh or (capabilities ~= PlayerInventory.graphCapabilities)
     forceGraphRefresh = false
+    PlayerInventory.graphCapabilities = capabilities
 
     -- Skip scan if addon not fully initialized yet
     if not QR.db then return end
@@ -640,9 +645,22 @@ function PlayerInventory:RegisterCombatCallback()
 end
 
 eventFrame:SetScript("OnEvent", function(self, event, ...)
-    -- Preserve capability/equipment invalidation even when this event joins a
-    -- pending BAG_UPDATE batch (e.g. looting and learning a riding spell).
-    if event ~= "BAG_UPDATE" then forceGraphRefresh = true end
+    -- Every event except BAG_UPDATE used to force a full graph rebuild here,
+    -- on the grounds that it might have changed something the teleport
+    -- comparison cannot see. SPELLS_CHANGED fires constantly for reasons that
+    -- have nothing to do with travel, and each firing cost a rebuild of the
+    -- whole graph plus a route for every tracked quest -- measured at 44 ms in
+    -- one frame with 51 teleports and 25 quests tracked, which is a visible
+    -- stutter and the one players reported.
+    --
+    -- What that force protected is now stated instead of assumed: the teleport
+    -- set is compared entry by entry, and PlayerInfo:CapabilitySignature covers
+    -- the rest of what CanUseTeleport reads -- faction, class, race,
+    -- Engineering. Equipment changes reach the comparison because an equipped
+    -- teleport carries its slot in the entry. The requirement checks the build
+    -- makes for flight edges depend on quest and phase state, which this force
+    -- never covered either: TravelRequirements marks the graph dirty on the
+    -- zone and world events that change them.
     -- A learned or unlearned spell is the only thing that changes a cast time.
     if event == "SPELLS_CHANGED" and QR.TravelTime then
         QR.TravelTime.castTimeBySpell = nil

--- a/QuickRoute/Modules/PlayerInventory.lua
+++ b/QuickRoute/Modules/PlayerInventory.lua
@@ -562,7 +562,6 @@ end
 local eventFrame = CreateFrame("Frame")
 PlayerInventory.eventFrame = eventFrame
 local debounceTimer = nil
-local forceGraphRefresh = false
 
 -- Ordinary loot still needs a bag scan, but unchanged teleport options do not
 -- require rebuilding every travel connection. Compare the flat scan records;
@@ -602,12 +601,13 @@ function PlayerInventory:RunDeferredScan()
     -- change here has to rebuild; an unchanged signature means the comparison
     -- below is the whole story.
     local capabilities = QR.PlayerInfo and QR.PlayerInfo:CapabilitySignature()
-    local force = forceGraphRefresh or (capabilities ~= PlayerInventory.graphCapabilities)
-    forceGraphRefresh = false
-    PlayerInventory.graphCapabilities = capabilities
+    local force = capabilities ~= PlayerInventory.graphCapabilities
 
     -- Skip scan if addon not fully initialized yet
     if not QR.db then return end
+    -- Recorded only now: stored above, it would be consumed by a scan that did
+    -- not run, and the change it described would never force a rebuild.
+    PlayerInventory.graphCapabilities = capabilities
 
     -- Perform the scan
     local before = not force and PlayerInventory:GetAllTeleports()
@@ -657,10 +657,16 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- set is compared entry by entry, and PlayerInfo:CapabilitySignature covers
     -- the rest of what CanUseTeleport reads -- faction, class, race,
     -- Engineering. Equipment changes reach the comparison because an equipped
-    -- teleport carries its slot in the entry. The requirement checks the build
-    -- makes for flight edges depend on quest and phase state, which this force
-    -- never covered either: TravelRequirements marks the graph dirty on the
-    -- zone and world events that change them.
+    -- teleport carries its slot in the entry.
+    --
+    -- The build also gates flight edges on TravelRequirements:Check, and an
+    -- edge it rejects is absent from the graph rather than filtered at search
+    -- time. What that check reads for a flight edge is whether the flight
+    -- master is discovered, plus faction on the four edges in TravelTransitions
+    -- that carry a requirement at all -- faction is in the signature, and
+    -- discovery is covered by the frame in PathCalculator that marks the graph
+    -- dirty on TAXIMAP_OPENED, TAXI_NODE_STATUS_CHANGED and the zone events.
+    -- Discovering a flight master means talking to one, which opens that map.
     -- A learned or unlearned spell is the only thing that changes a cast time.
     if event == "SPELLS_CHANGED" and QR.TravelTime then
         QR.TravelTime.castTimeBySpell = nil
@@ -672,8 +678,8 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     -- stay set, and the guard below would then swallow every inventory event
     -- for the rest of the session. Releasing both flags lets this event arm a
     -- timer as usual, so the recovered scan is still debounced rather than run
-    -- inside an event handler. forceGraphRefresh is untouched and still
-    -- carries what the fight accumulated.
+    -- inside an event handler. The capability signature is compared when the
+    -- scan finally runs, so a change made during the fight is still noticed.
     if PlayerInventory.scanDeferredByCombat and not InCombatLockdown() then
         PlayerInventory.scanDeferredByCombat = false
         PlayerInventory.pendingScan = false
@@ -699,8 +705,7 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
         -- Bags, spells and cooldowns churn constantly during a fight, and
         -- scanning them walks every bag slot and every known teleport. Leaving
         -- pendingScan set makes the rest of the fight's events fold into this
-        -- one deferred scan, which the leave-combat callback then runs; the
-        -- accumulated forceGraphRefresh stays set for it too.
+        -- one deferred scan, which the leave-combat callback then runs.
         if InCombatLockdown() then
             PlayerInventory.scanDeferredByCombat = true
             return

--- a/QuickRoute/Utils/PlayerInfo.lua
+++ b/QuickRoute/Utils/PlayerInfo.lua
@@ -84,6 +84,25 @@ function PlayerInfo:CanUseTeleport(data)
     return true
 end
 
+--- A fingerprint of everything about the player that the travel graph is built
+-- against. Faction, class and race decide which teleports exist for this
+-- character at all, and Engineering gates the profession-only ones -- exactly
+-- the inputs CanUseTeleport reads. All four are cached, so this costs four
+-- table reads once the cache is warm.
+--
+-- It exists so that an inventory event does not have to assume the worst. The
+-- teleport set is compared directly; this covers the rest of what a rebuild
+-- would have picked up.
+-- @return string
+function PlayerInfo:CapabilitySignature()
+    return table.concat({
+        tostring(self:GetFaction()),
+        tostring(self:GetClass()),
+        tostring(self:GetRace()),
+        tostring(self:HasEngineering()),
+    }, "|")
+end
+
 --- Check if player class matches the given class name
 -- @param className string Uppercase class token to check (e.g. "MAGE")
 -- @return boolean True if the player's class matches

--- a/tests/test_inventory_graph_invalidation.lua
+++ b/tests/test_inventory_graph_invalidation.lua
@@ -76,18 +76,55 @@ T:run("Inventory events: changed source and usability remain routing changes", f
     end)
 end)
 
+-- These events used to invalidate the travel graph unconditionally, on the
+-- grounds that they might have changed something the teleport comparison
+-- cannot see. What they can change is now stated: PlayerInfo's capability
+-- signature. The pair below keeps the property the blanket force existed for --
+-- a capability change is not lost when the event coalesces into a pending
+-- BAG_UPDATE batch, which is the "looting while learning a riding spell" case
+-- -- and adds the half that was previously untestable: an event that changed
+-- nothing costs nothing.
 for _, event in ipairs({ "PLAYER_EQUIPMENT_CHANGED", "SPELLS_CHANGED", "TOYS_UPDATED", "SKILL_LINES_CHANGED" }) do
-    T:run("Inventory events: coalesced " .. event .. " still invalidates unchanged teleports", function(t)
+    T:run("Inventory events: coalesced " .. event .. " with a capability change invalidates", function(t)
         withInventoryEvents(function(f)
+            local savedProfessions = MockWoW.config.professions
+            MockWoW.config.professions = {}
+            QR.PlayerInfo:InvalidateCache()
+            QR.PlayerInventory.graphCapabilities = QR.PlayerInfo:CapabilitySignature()
+
+            -- The player picks up Engineering, which decides whether the
+            -- profession-only teleports exist for this character at all.
+            MockWoW.config.professions = {
+                { name = "Engineering", skillLineID = 202 },
+            }
+            QR.PlayerInfo:InvalidateCache()
+
             f.fire("BAG_UPDATE")
             f.fire(event)
             f.flush()
             local scans, notifications = f.counts()
             t:assertEqual(1, scans, "Coalesced events use one inventory scan")
-            t:assertEqual(1, notifications, "Capability or equipment changes still invalidate routes")
+            t:assertEqual(1, notifications, "The capability change still invalidates routes")
             f.fire("BAG_UPDATE"); f.flush()
             local _, later = f.counts()
-            t:assertEqual(1, later, "The forced refresh does not leak into the next ordinary loot batch")
+            t:assertEqual(1, later, "and does not leak into the next ordinary loot batch")
+
+            MockWoW.config.professions = savedProfessions
+            QR.PlayerInfo:InvalidateCache()
+        end)
+    end)
+
+    T:run("Inventory events: coalesced " .. event .. " that changed nothing does not invalidate", function(t)
+        withInventoryEvents(function(f)
+            QR.PlayerInfo:InvalidateCache()
+            QR.PlayerInventory.graphCapabilities = QR.PlayerInfo:CapabilitySignature()
+            f.fire("BAG_UPDATE")
+            f.fire(event)
+            f.flush()
+            local scans, notifications = f.counts()
+            t:assertEqual(1, scans, "the inventory is still rescanned")
+            t:assertEqual(0, notifications,
+                "no teleport and no capability changed, so the graph is left alone")
         end)
     end)
 end


### PR DESCRIPTION
The reporter of #66 tried 1.18.3 and says the stutter is still there — every five to ten seconds now rather than every second, still only while moving. Their new recording shows client-wide CPU sitting at 3–4 % and spiking to 25–53 % while walking.

## What it is

Measured on 1.18.3 with 51 teleports and 25 tracked quests, one firing of each event the inventory watcher listens to:

| event | cost | rebuilds | routes |
|---|---|---|---|
| `QUEST_LOG_UPDATE` | 0.95 ms | 0 | 0 |
| **`SPELLS_CHANGED`** | **44.38 ms** | **1** | **8** |
| `TOYS_UPDATED`, `PLAYER_EQUIPMENT_CHANGED`, `BAG_UPDATE`, `SKILL_LINES_CHANGED` | ~0.06 ms | 0 | 0 |

44 ms in a single frame is a visible stutter at any frame rate, and `SPELLS_CHANGED` fires constantly for reasons that have nothing to do with travel — which is also why the cost rose with the number of addons installed. The graph build alone is 32–36 ms on this character; the rest is a route for each quest that then finds a new graph.

The 1.18.3 work removed the per-second cost, which is why the reported cadence moved from "every second" to "every five to ten seconds". This is what is left.

## The fix

Every event except `BAG_UPDATE` marked the graph dirty, on the grounds that it might have changed something the teleport comparison cannot see. What that protects is now stated rather than assumed:

- the teleport set is already compared entry by entry, and an equipped teleport carries its slot in its entry, so equipment reaches that comparison;
- `PlayerInfo:CapabilitySignature` covers the rest of what `CanUseTeleport` reads — faction, class, race, Engineering — from four values the module already caches.

The requirement checks the build makes for flight edges depend on quest and phase state. The blanket force never covered those either — nothing fires `SPELLS_CHANGED` when a quest is completed — and `TravelRequirements` continues to mark the graph dirty on the zone and world events that do change them.

Same fixture after: `SPELLS_CHANGED` costs **0.29 ms**, no rebuild, no routes.

## Tests

Four tests pinned the blanket force, asserting that these events invalidate even when nothing changed. Their subject — named in the production comment they guard — is that a capability change is not lost when the event coalesces into a pending `BAG_UPDATE` batch, the "looting while learning a riding spell" case. They now do that literally, by giving the character Engineering, and gain the half that was not testable before: an event that changed nothing invalidates nothing.

Dropping the signature fails eight assertions; restoring the blanket force fails four. Suite 16,084 → 16,088, 0 failures in both orders; luacheck clean.

Not confirmed against the reporter's client yet — this is measured here, and the cadence and the addon-count dependence both match what they describe.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
