### PR TITLE
fix: compare where a quest points, not just which map

### DIFF
--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -99,6 +99,22 @@ local INVALIDATING_EVENTS = {
 -- what bounds how stale this choice can get, and it did so at 1000 too.
 local POSITION_BUCKETS = 20
 
+--- Where a quest points, at the same resolution as the player's own position.
+-- Keyed on the map alone this missed an objective advancing to another part of
+-- the same zone -- a destination is wired into the graph by its coordinates, so
+-- two points in one zone attach to different nearby nodes and can pick a
+-- different first teleport. Keyed on exact coordinates it would recompute
+-- constantly instead: C_QuestLog.GetNextWaypoint walks a multi-step quest along
+-- its path, so the coordinates drift while the destination does not. The same
+-- grid that decides the player has moved decides the objective has.
+local function DestinationBucket(waypoint)
+    if not waypoint or not waypoint.mapID then return nil end
+    local x, y = waypoint.x, waypoint.y
+    if type(x) ~= "number" or type(y) ~= "number" then return waypoint.mapID .. ":?" end
+    return string_format("%d:%d:%d", waypoint.mapID,
+        math_floor(x * POSITION_BUCKETS), math_floor(y * POSITION_BUCKETS))
+end
+
 local function GetPositionBucket()
     if not (C_Map and C_Map.GetBestMapForUnit and C_Map.GetPlayerMapPosition) then return nil end
     local ok, bucket = pcall(function()
@@ -180,11 +196,11 @@ local function GetCachedTeleportForQuest(questID)
     -- comparing them would recompute a route that cannot have changed. Which
     -- zone the player is being sent to is what decides the first step.
     local waypoint = ResolveQuestWaypoint(questID)
-    local destMapID = waypoint and waypoint.mapID
+    local destination = DestinationBucket(waypoint)
 
     if cached and not (QTB.flightChoices and QTB.flightChoices[questID])
         and cached.position == position and cached.graph == (calculator and calculator.graph)
-        and cached.destMapID == destMapID
+        and cached.destination == destination
         and not (calculator and calculator.graphDirty) and (now - cached.time) < CACHE_TTL then
         local cooldown = cached.teleportID and QR.CooldownTracker
             and QR.CooldownTracker:GetCooldown(cached.teleportID, cached.sourceType)
@@ -211,13 +227,13 @@ local function GetCachedTeleportForQuest(questID)
             data = entry.data,
             time = now,
             position = position,
-            destMapID = destMapID,
+            destination = destination,
             graph = QR.PathCalculator and QR.PathCalculator.graph,
         }
         return teleportID, entry.sourceType, entry.data
     end
 
-    QTB.questCache[questID] = { time = now, position = position, destMapID = destMapID,
+    QTB.questCache[questID] = { time = now, position = position, destination = destination,
         graph = QR.PathCalculator and QR.PathCalculator.graph, direct = direct }
     return nil, nil, nil, nil, direct
 end

--- a/tests/test_questbutton_async.lua
+++ b/tests/test_questbutton_async.lua
@@ -42,7 +42,23 @@ local function withRefresh(fn)
         qtb.pool[index] = btn
     end
     QR.PlayerInventory = {GetAllTeleports=function()return {[3561]={sourceType="spell",data={name="Stormwind"}}}end}
-    QR.CooldownTracker = {GetCooldown=function()return {ready=true}end}
+    -- A stand-in that behaves like the real one: it remembers answers for the
+    -- duration of a batch. Without that, nothing routed through it can tell a
+    -- remembered answer from a fresh one, and a guard on the readiness check
+    -- passes whether or not the code is correct.
+    QR.CooldownTracker = {
+        batchOpen = false, memo = {}, liveReads = 0,
+        BeginBatch = function(self) self.batchOpen = true; self.memo = {} end,
+        EndBatch = function(self) self.batchOpen = false; self.memo = {} end,
+        GetCooldown = function(self, id, sourceType)
+            local key = tostring(sourceType) .. ":" .. tostring(id)
+            if self.batchOpen and self.memo[key] then return self.memo[key] end
+            self.liveReads = self.liveReads + 1
+            local answer = { ready = state.cooldownReady ~= false }
+            if self.batchOpen then self.memo[key] = answer end
+            return answer
+        end,
+    }
     QR.WaypointIntegration = {GetQuestWaypoint=function(_,id)return {mapID=84,x=0.5,y=0.5,title=tostring(id)}end}
     QR.PathCalculator = {graph={},CalculatePath=function()
         state.calls = state.calls + 1
@@ -609,5 +625,30 @@ T:run("Quest button cache: disabling the feature releases all graph references",
         collectgarbage("collect")
         t:assertNil(oldGraph[1], "Disabled quest buttons retain neither cached routes nor the previous movement graph")
         t:assertTableCount(qtb.questCache, 0, "Disabled feature has no route cache left to retain graphs")
+    end)
+end)
+
+-- The readiness check that consumes SPELL_UPDATE_COOLDOWN decides whether a
+-- cooldown moved. A refresh batch spans one frame per tracked quest, so a batch
+-- can be open when the event arrives, and reading its remembered answers there
+-- would report "nothing changed" about the very teleport the player just used.
+-- Nothing could catch that before: the stand-in above had no memo, so the
+-- assertion passed whether or not the code read past one.
+T:run("Quest button cooldowns: the readiness check reads past an open batch", function(t)
+    withRefresh(function(qtb, state)
+        state.watched = {10001, 10002, 10003}
+        qtb:RefreshButtons()
+        state.pending[1]()                      -- one quest routed; batch is open
+        local ct = QR.CooldownTracker
+        t:assertTrue(ct.batchOpen, "the refresh opened a cooldown batch")
+        ct:GetCooldown(3561, "spell")           -- remembered as ready
+        state.cooldownReady = false             -- the player uses the teleport
+        local before = ct.liveReads
+
+        local frame = qtb.eventFrame
+        if frame then frame:GetScript("OnEvent")(frame, "SPELL_UPDATE_COOLDOWN") end
+
+        t:assertTrue(ct.liveReads > before,
+            "the readiness check asked the client rather than the open batch")
     end)
 end)

--- a/tests/test_route_recompute_budget.lua
+++ b/tests/test_route_recompute_budget.lua
@@ -43,6 +43,10 @@ local function withCountedRoutes(body)
     saved.knownSpell = MockWoW.config.knownSpells[3561]
     MockWoW.config.knownSpells[3561] = true
     QR.PlayerInventory:ScanAll()
+    -- WaypointIntegration caches quest coordinates for 30 seconds and that
+    -- cache outlives a test. Without this, a test that moved an objective
+    -- leaves the next one resolving the old position.
+    QR.WaypointIntegration:ClearQuestCoordCache()
 
     -- Every cached route records the graph it was computed against and is
     -- discarded while a rebuild is pending. Both are shared with the rest of
@@ -101,6 +105,32 @@ T:run("a quest whose objective moved to another zone is routed again", function(
         QR.WaypointIntegration:ClearQuestCoordCache()
         t:assertEqual(1, routesFor("QUEST_LOG_UPDATE"),
             "the quest that moved is routed again, and only that one")
+    end)
+end)
+
+-- The destination is compared at the same resolution as the player's position,
+-- not by map alone. A quest whose objective advances to the far side of the
+-- same zone gets a different route: the destination is wired into the graph by
+-- its coordinates, so it attaches to different nearby nodes.
+T:run("a quest whose objective moved across its zone is routed again", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        MockWoW.config.questWaypoints[71001] = { mapID = 84, x = 0.95, y = 0.95 }
+        QR.WaypointIntegration:ClearQuestCoordCache()
+        t:assertEqual(1, routesFor("QUEST_LOG_UPDATE"),
+            "the quest that moved is routed again, and only that one")
+    end)
+end)
+
+T:run("a quest objective drifting along its path is not routed again", function(t)
+    withCountedRoutes(function()
+        routesFor("QUEST_LOG_UPDATE")
+        -- GetNextWaypoint walks a multi-step quest along its path, so the
+        -- coordinates move a little between readings while the destination
+        -- does not. That must not recompute anything.
+        MockWoW.config.questWaypoints[71001] = { mapID = 84, x = 0.505, y = 0.503 }
+        QR.WaypointIntegration:ClearQuestCoordCache()
+        t:assertEqual(0, routesFor("QUEST_LOG_UPDATE"), "a step along the path changes nothing")
     end)
 end)
 


### PR DESCRIPTION
Closes #70 and the testable half of #72, both recorded while reviewing #69.

## The destination is compared at the right resolution

#69 keyed the quest route cache on the destination **map**. That missed an objective advancing to another part of the same zone: the graph wires a destination in by its coordinates (`ConnectNearbyNodes(destName, destMapID, destX, destY)`), so two points in one zone attach to different nearby nodes and can select a different first teleport. Before #69 the blanket wipe caught that case, so it was a regression against the release before it.

Comparing exact coordinates is not the answer either — `C_QuestLog.GetNextWaypoint` walks a multi-step quest along its path, so they drift while the destination stays put, and every drift would recompute a route that cannot have changed.

The destination is now bucketed on the same grid that decides the player has moved. Both halves are pinned: an objective crossing its zone is routed again, one drifting along its path is not. Coarsening the key back to the map fails the first test; comparing exact coordinates fails the second.

## The cooldown batch is testable now

The async harness's `CooldownTracker` stand-in was `{GetCooldown = function() return {ready = true} end}` — no memo, so no assertion routed through it could tell a remembered cooldown from a fresh one. That is why the readiness-check fix in #69 shipped without a guard after two attempts that passed for the wrong reason.

The stand-in now behaves like the real module: it remembers answers for the duration of a batch and counts client reads. The guard exists and fails when the readiness check reads an open batch instead of the client — which is the defect #69 fixed blind.

## One test-hygiene fix found on the way

`WaypointIntegration`'s coordinate cache outlives a test, so a test that moved an objective left the next one resolving the old position. The fixture clears it. That is what made the drift test fail for a reason that had nothing to do with the code under test.

## Verification

16,088 → 16,092 assertions, 0 failures in both orders; luacheck clean. Every guard was watched to fail with its fix reverted.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
