### PR TITLE
fix: the global cooldown is not a reason to replan every quest

### DIFF
--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -97,6 +97,10 @@ local INVALIDATING_EVENTS = {
 -- to walk to -- is not answered by any divisor: CACHE_TTL already expires every
 -- entry within 30 seconds regardless of where the player stands, so that is
 -- what bounds how stale this choice can get, and it did so at 1000 too.
+-- The longest a teleport can be unavailable without it being worth replanning.
+-- The global cooldown is 1.5 seconds and every item and toy teleport shares it.
+local GLOBAL_COOLDOWN = 1.5
+
 local POSITION_BUCKETS = 20
 
 --- Where a quest points, at the same resolution as the player's own position.
@@ -280,7 +284,21 @@ local function UpdateCooldownState()
     local teleports = QR.PlayerInventory and QR.PlayerInventory:GetAllTeleports() or {}
     for id, entry in pairs(teleports) do
         local cooldown = QR.CooldownTracker and QR.CooldownTracker:GetCooldown(id, entry.sourceType)
-        current[id] = cooldown and cooldown.ready or false
+        -- A teleport that is a global cooldown away from being usable counts as
+        -- ready HERE, which is a question about replanning and not about what
+        -- the player is shown. Items and toys share the global cooldown, so
+        -- pressing any ability at all flips every one of them to unavailable
+        -- for about a second and a half; taking that for a readiness change
+        -- emptied the quest route cache and re-routed every tracked quest on
+        -- every keypress -- measured at 13.8 ms and eight routes per press with
+        -- 52 teleports and 25 quests tracked. No route can change over a window
+        -- that closes before the player could act on the answer.
+        --
+        -- CooldownTracker deliberately does not make this inference when it
+        -- reports a cooldown, because a short real cooldown is a real cooldown.
+        -- That is the reporting question; this is the planning one.
+        local remaining = cooldown and cooldown.remaining or 0
+        current[id] = (cooldown and cooldown.ready) or remaining <= GLOBAL_COOLDOWN or false
         if current[id] ~= previous[id] then changed = true end
     end
     for id in pairs(previous) do

--- a/tests/test_spell_global_cooldown.lua
+++ b/tests/test_spell_global_cooldown.lua
@@ -1,4 +1,4 @@
-local T, QR = ...
+local T, QR, MockWoW = ...
 
 local function isolated(body)
     local changes = {}
@@ -148,4 +148,76 @@ T:run("Spell cooldown: GCD-only events do not notify views or arm expiry timers"
         t:assertEqual(3, callbacks, "A real personal cooldown still notifies the visible view")
         t:assertEqual(1, timers, "A real personal cooldown still schedules its expiry")
     end)
+end)
+
+-- Items and toys share the global cooldown, so pressing any ability at all
+-- makes every one of them unavailable for about a second and a half. Treating
+-- that as a readiness change emptied the quest route cache and re-routed every
+-- tracked quest on every keypress. No route can change over a window that
+-- closes before the player could act on the answer.
+T:run("Quest replanning: the global cooldown is not a readiness change", function(t)
+    local QTB = QR.QuestTeleportButtons
+    if not QTB.initialized then QTB:Initialize() end
+    local saved = {
+        combat = MockWoW.config.inCombatLockdown,
+        time = MockWoW.config.baseTime,
+        cooldowns = MockWoW.config.spellCooldowns,
+        items = MockWoW.config.itemCooldowns,
+        state = QTB.cooldownState,
+        watches = MockWoW.config.questWatches,
+    }
+    MockWoW.config.inCombatLockdown = false
+    MockWoW.config.baseTime = 1000000
+    MockWoW.config.spellCooldowns, MockWoW.config.itemCooldowns = {}, {}
+    MockWoW.config.knownSpells[3561] = true
+    QR.PlayerInventory:ScanAll()
+
+    -- Quests to route, or a wiped cache costs nothing and the assertion below
+    -- would hold whether or not the code is right.
+    saved.waypoints, saved.titles = MockWoW.config.questWaypoints, MockWoW.config.questTitles
+    MockWoW.config.questWatches = { 78001, 78002, 78003 }
+    MockWoW.config.questWaypoints, MockWoW.config.questTitles = {}, {}
+    for _, id in ipairs(MockWoW.config.questWatches) do
+        MockWoW.config.questWaypoints[id] = { mapID = 84, x = 0.5, y = 0.5 }
+        MockWoW.config.questTitles[id] = "GCD quest " .. id
+    end
+    QR.WaypointIntegration:ClearQuestCoordCache()
+    QTB:InvalidateCache()
+    if not QR.PathCalculator.graph then QR.PathCalculator:BuildGraph() end
+    QR.PathCalculator.graphDirty = false
+
+    local routes = 0
+    local realCalc = QR.PathCalculator.CalculatePath
+    QR.PathCalculator.CalculatePath = function(self, ...)
+        routes = routes + 1
+        return realCalc(self, ...)
+    end
+
+    local frame = QTB.eventFrame
+    frame:GetScript("OnEvent")(frame, "QUEST_LOG_UPDATE")        -- fill the cache
+    frame:GetScript("OnEvent")(frame, "SPELL_UPDATE_COOLDOWN")   -- settle the state
+    t:assertNotNil(next(QTB.questCache), "the quests are cached before the ability press")
+    routes = 0
+
+    -- One ability press: everything that shares the global cooldown reports a
+    -- 1.5s wait.
+    MockWoW.config.spellCooldowns[3561] = { start = 1000000, duration = 1.5, enable = 1 }
+    frame:GetScript("OnEvent")(frame, "SPELL_UPDATE_COOLDOWN")
+    t:assertEqual(0, routes, "a global cooldown does not re-route anything")
+
+    -- A real teleport cooldown still does. The refresh that follows refills the
+    -- cache in the same breath here, because the mock runs timers immediately,
+    -- so the observable is the routing rather than an empty table.
+    routes = 0
+    MockWoW.config.spellCooldowns[3561] = { start = 1000000, duration = 1800, enable = 1 }
+    frame:GetScript("OnEvent")(frame, "SPELL_UPDATE_COOLDOWN")
+    t:assertTrue(routes > 0, "a real cooldown still re-routes the tracked quests")
+
+    QR.PathCalculator.CalculatePath = realCalc
+    QTB.cooldownState = saved.state
+    MockWoW.config.spellCooldowns, MockWoW.config.itemCooldowns = saved.cooldowns, saved.items
+    MockWoW.config.baseTime = saved.time
+    MockWoW.config.inCombatLockdown = saved.combat
+    MockWoW.config.questWatches = saved.watches
+    MockWoW.config.questWaypoints, MockWoW.config.questTitles = saved.waypoints, saved.titles
 end)


### PR DESCRIPTION
The reporter of [#66](https://github.com/CybotTM/wow-quickroute/issues/66) says 1.18.4 did not settle it, and gave the two observations that find it: the spikes track distance and his movement ability, and *"I also noticed spikes whenever I use pretty much any ability."*

## Any ability press re-routed every tracked quest

Items and toys share the global cooldown, so pressing any ability at all makes every item and toy teleport report about 1.5 seconds of unavailability. `UpdateCooldownState` took that for a change in readiness, and a readiness change empties the quest route cache and re-routes every tracked quest.

Measured with 52 teleports and 25 quests tracked, per keypress:

| | cost | routes | client cooldown reads |
|---|---|---|---|
| before | 13.82 ms | 8 | 118 |
| after | **0.02 ms** | **0** | 52 |

No route can change over a window that closes before the player could act on the answer, so a teleport that is one global cooldown away from usable now counts as ready **for the purpose of deciding whether to replan**.

`CooldownTracker` deliberately refuses that inference when it *reports* a cooldown — a short real cooldown is a real cooldown, and its comment says so explicitly. That is the reporting question; this is the planning one, and they want different answers. A real teleport cooldown still invalidates and still re-routes.

The remaining 52 reads per press are the detector walking the teleport list. That is C-side, unchanged here, and tracked in [#71](https://github.com/CybotTM/wow-quickroute/issues/71)'s neighbourhood.

## Still open after this

The other half of the report — *"it seems to be distance-based, more often when I use my movement ability"* — is the position bucket: crossing one re-routes every tracked quest, and a movement ability crosses buckets quickly. That is a burst of eight routes at 2–3 ms each, one per frame, and it is not addressed here.

## Tests

Both directions pinned in the file that already owns the global-cooldown rules, each watched to fail: treating the global cooldown as a change again re-routes on the keypress, and treating everything as ready loses a real cooldown.

The first version of the guard asserted against a suite with no tracked quests, so it passed whether or not the code was right — it sets up its own quests now. Suite 16,092 → 16,095, 0 failures in both orders; luacheck clean.

Measured here, not in the reporter's client. His description is what located it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
