### PR TITLE
chore(release): 1.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.18.5] - 2026-09-09
+
+### Fixed
+- Stopped treating the global cooldown as a reason to reconsider every tracked quest's teleport. Items and toys share it, so pressing any ability at all made all of them briefly unavailable and cost a route calculation per tracked quest — 13.8 ms on every keypress with 52 teleports and 25 quests tracked.
+- Stopped re-routing when the player crosses an invisible grid line. Whether a computed route still applies is now a question of how far the player has moved from where it was computed, so circling an objective or strafing across one spot no longer recomputes anything — measured at 80 route calculations for ten small steps back and forth across a boundary, and none after.
+
 ## [1.18.4] - 2026-09-09
 
 ### Fixed
@@ -404,7 +410,8 @@
 - CI pipeline (luacheck + tests)
 - CurseForge + Wago automated publishing
 
-[Unreleased]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.4...HEAD
+[Unreleased]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.5...HEAD
+[1.18.5]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.4...v1.18.5
 [1.18.4]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.3...v1.18.4
 [1.18.3]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/CybotTM/wow-quickroute/compare/v1.18.1...v1.18.2

--- a/QuickRoute/QuickRoute.toc
+++ b/QuickRoute/QuickRoute.toc
@@ -2,7 +2,7 @@
 ## Title: QuickRoute
 ## Notes: Estimates fast routes to destinations using known teleports, portals and transports
 ## Author: Sebastian Mendel
-## Version: 1.18.4
+## Version: 1.18.5
 ## SavedVariables: QuickRouteDB
 ## OptionalDeps: TomTom
 ## X-Category: Map


### PR DESCRIPTION
Cuts 1.18.5 from the global-cooldown replan in [#77](https://github.com/CybotTM/wow-quickroute/pull/77) and the position boundary in [#78](https://github.com/CybotTM/wow-quickroute/pull/78) — the two halves of what the reporter of [#66](https://github.com/CybotTM/wow-quickroute/issues/66) described.

- `QuickRoute.toc`: 1.18.4 → 1.18.5
- `CHANGELOG.md`: a 1.18.5 section, dated, with the compare links

No code changes.
