### PR TITLE
fix(quest-buttons): keep the cooldown memo and the route across a transient event

### DIFF
--- a/QuickRoute/Modules/CooldownTracker.lua
+++ b/QuickRoute/Modules/CooldownTracker.lua
@@ -285,6 +285,29 @@ function CooldownTracker:EndBatch()
     if self.batchMemo then wipe(self.batchMemo) end
 end
 
+--- Read the client rather than the memo, without discarding it.
+-- For the one caller that has to see live state in the middle of somebody
+-- else's batch: the readiness check that decides whether a cooldown moved. It
+-- used to end the batch outright, which is correct but throws away the memo of
+-- a refresh that is still running -- and SPELL_UPDATE_COOLDOWN fires on every
+-- global cooldown, so that was the common case rather than the rare one.
+-- @return boolean Whether a batch was open, to hand back to ResumeBatch
+function CooldownTracker:SuspendBatch()
+    local wasOpen = self.batchOpen or false
+    self.batchOpen = false
+    return wasOpen
+end
+
+--- Reopen a batch suspended by SuspendBatch, with its memo intact.
+-- Only sound when the caller established that nothing it cares about moved --
+-- otherwise the memo would answer the rest of the batch with the state from
+-- before the change. EndBatch is the other exit, and it is the right one
+-- whenever readiness did move.
+-- @param wasOpen boolean The value SuspendBatch returned
+function CooldownTracker:ResumeBatch(wasOpen)
+    if wasOpen then self.batchOpen = true end
+end
+
 function CooldownTracker:GetCooldown(id, sourceType)
     -- A batch is closed on every path that leaves a refresh, but the tail of
     -- that refresh is not all inside a pcall: an error there would leave one

--- a/QuickRoute/Modules/QuestTeleportButtons.lua
+++ b/QuickRoute/Modules/QuestTeleportButtons.lua
@@ -242,10 +242,23 @@ local function GetCachedTeleportForQuest(questID)
     local waypoint = ResolveQuestWaypoint(questID)
     local destination = DestinationBucket(waypoint)
 
+    -- A destination the client cannot state right now is not a quest that
+    -- points nowhere, and the two arrive here as the same nil. Comparing them
+    -- evicted a good entry over a gap the rest of the module is built to ride
+    -- out: the miss recomputed with no waypoint, came back incomplete, deleted
+    -- the entry and cleared the button, leaving an icon on screen that does
+    -- nothing until PENDING_GRACE hides it. Before the destination joined this
+    -- key a hit never consulted the waypoint layer at all.
+    --
+    -- What this stops detecting: a quest that genuinely loses its waypoint for
+    -- good keeps its cached teleport until the TTL, the player moves, or the
+    -- graph changes -- at most CACHE_TTL, and what happened before #69.
+    local destinationKnown = destination ~= nil
+
     if cached and not (QTB.flightChoices and QTB.flightChoices[questID])
         and PositionStillValid(cached.position, mapID, px, py)
         and cached.graph == (calculator and calculator.graph)
-        and cached.destination == destination
+        and (not destinationKnown or cached.destination == destination)
         and not (calculator and calculator.graphDirty) and (now - cached.time) < CACHE_TTL then
         local cooldown = cached.teleportID and QR.CooldownTracker
             and QR.CooldownTracker:GetCooldown(cached.teleportID, cached.sourceType)
@@ -320,7 +333,16 @@ local function UpdateCooldownState()
     -- one can still be open when SPELL_UPDATE_COOLDOWN arrives; reading its
     -- memo here would report "nothing changed" for the very teleport the player
     -- just used, and the rest of the batch would hand out a button for it.
-    EndCooldownBatch()
+    --
+    -- Suspended rather than ended, because this event arrives on every global
+    -- cooldown and almost always finds nothing moved. Ending it stripped a
+    -- running refresh of its memo for its remaining frames -- 12 client reads
+    -- for a refresh of 12 quests where an undisturbed one takes 3 -- and gave
+    -- back the saving on the path that fires most often. The scan below reads
+    -- live either way; only what happens afterwards differs.
+    local ct = QR.CooldownTracker
+    local suspended = ct and ct.SuspendBatch and ct:SuspendBatch()
+    if not (ct and ct.SuspendBatch) then EndCooldownBatch() end
     local previous = QTB.cooldownState or {}
     local current, changed = {}, false
     local teleports = QR.PlayerInventory and QR.PlayerInventory:GetAllTeleports() or {}
@@ -347,6 +369,14 @@ local function UpdateCooldownState()
         if current[id] == nil then changed = true end
     end
     QTB.cooldownState = current
+    -- A readiness that moved invalidates the cache and re-routes, so the memo
+    -- of the batch that was running describes a world that no longer holds:
+    -- drop it. Nothing moved means the memo is still the same answer it was.
+    if changed then
+        EndCooldownBatch()
+    elseif ct and ct.ResumeBatch then
+        ct:ResumeBatch(suspended)
+    end
     return changed
 end
 

--- a/tests/test_questbutton_async.lua
+++ b/tests/test_questbutton_async.lua
@@ -50,11 +50,22 @@ local function withRefresh(fn)
         batchOpen = false, memo = {}, liveReads = 0,
         BeginBatch = function(self) self.batchOpen = true; self.memo = {} end,
         EndBatch = function(self) self.batchOpen = false; self.memo = {} end,
+        SuspendBatch = function(self)
+            local wasOpen = self.batchOpen or false
+            self.batchOpen = false
+            return wasOpen
+        end,
+        ResumeBatch = function(self, wasOpen) if wasOpen then self.batchOpen = true end end,
         GetCooldown = function(self, id, sourceType)
             local key = tostring(sourceType) .. ":" .. tostring(id)
             if self.batchOpen and self.memo[key] then return self.memo[key] end
             self.liveReads = self.liveReads + 1
-            local answer = { ready = state.cooldownReady ~= false }
+            -- remaining, not only ready: the readiness check treats anything
+            -- within a global cooldown of usable as ready, so an answer with no
+            -- remaining reads as ready whatever `ready` says -- and every flip
+            -- of state.cooldownReady below was invisible to it.
+            local ready = state.cooldownReady ~= false
+            local answer = { ready = ready, remaining = ready and 0 or 900 }
             if self.batchOpen then self.memo[key] = answer end
             return answer
         end,
@@ -650,5 +661,51 @@ T:run("Quest button cooldowns: the readiness check reads past an open batch", fu
 
         t:assertTrue(ct.liveReads > before,
             "the readiness check asked the client rather than the open batch")
+    end)
+end)
+
+-- The same event, when nothing moved. It fires on every global cooldown, so
+-- this is the common case: ending the batch here stripped the refresh that is
+-- still running of its memo for all of its remaining frames, and every one of
+-- those quests went back to asking the client.
+T:run("Quest button cooldowns: an unrelated cooldown event leaves a running batch its memo", function(t)
+    withRefresh(function(qtb, state)
+        state.watched = {10001, 10002, 10003}
+        qtb:RefreshButtons()
+        state.pending[1]()                      -- one quest routed; batch is open
+        local ct = QR.CooldownTracker
+        t:assertTrue(ct.batchOpen, "the refresh opened a cooldown batch")
+
+        local frame = qtb.eventFrame
+        if frame then frame:GetScript("OnEvent")(frame, "SPELL_UPDATE_COOLDOWN") end
+        t:assertTrue(ct.batchOpen, "a batch that was open is still open afterwards")
+
+        local before = ct.liveReads
+        while state.pending[1] do table.remove(state.pending, 1)() end
+        t:assertEqual(before, ct.liveReads,
+            "the rest of the refresh answered from the memo the event left alone")
+    end)
+end)
+
+-- A cache hit used to be decided without the waypoint layer. Since the
+-- destination joined the key it is consulted on every read, and a client that
+-- cannot say where a quest points for one frame produced a nil that read as a
+-- changed destination -- evicting an entry that was right.
+T:run("Quest button routes: a momentary waypoint gap keeps the cached teleport", function(t)
+    withRefresh(function(qtb, state)
+        state.watched = {10001}
+        refreshOne(qtb, state)
+        local btn = qtb.activeButtons[10001]
+        t:assertNotNil(qtb.questCache[10001], "the quest routed and cached")
+        local calls = state.calls
+
+        local waypoint = QR.WaypointIntegration.GetQuestWaypoint
+        QR.WaypointIntegration.GetQuestWaypoint = function() return nil end
+        refreshOne(qtb, state)
+        QR.WaypointIntegration.GetQuestWaypoint = waypoint
+
+        t:assertNotNil(qtb.questCache[10001], "the gap did not evict the cached route")
+        t:assertEqual("spell", btn:GetAttribute("type"), "the button kept its action")
+        t:assertEqual(calls, state.calls, "and no route was calculated over the gap")
     end)
 end)


### PR DESCRIPTION
Both halves of [#72](https://github.com/CybotTM/wow-quickroute/issues/72), from the adversarial review of [#69](https://github.com/CybotTM/wow-quickroute/pull/69).

## The readiness check stripped a running refresh of its memo

`UpdateCooldownState` ended the cooldown batch as its first act so it would see the client rather than the batch's remembered answers. Seeing live is right; ending is more than that costs. `SPELL_UPDATE_COOLDOWN` fires on every global cooldown and almost always finds nothing moved, so a refresh that was still running went on for its remaining frames with no memo.

| refresh of 12 quests | client cooldown reads |
|---|---|
| undisturbed | 3 |
| one unrelated `SPELL_UPDATE_COOLDOWN` mid-batch | 12 |
| before #69, no batch at all | 10 |

`CooldownTracker` gains `SuspendBatch`/`ResumeBatch`. The scan reads live either way — that part is unchanged. What differs is afterwards: the batch is ended only when a readiness really moved, which is also the moment its memo stops being true, and otherwise it is reopened with what it had.

The issue records an earlier attempt at this that broke 25 tests by adding a live-read accessor. This does not need one: nothing reads past the memo, the memo is simply not discarded.

**What resuming the batch stops detecting:** the readiness check counts anything within a global cooldown of usable as ready, so a teleport going from 1.4 seconds remaining to genuinely ready is not a change — and the resumed memo still answers "not ready" for it. The button for that teleport appears one refresh later than it would have. The window is bounded by the batch, which is a frame per tracked quest and at most `BATCH_MAX_SECONDS`. That is the price of the 12-reads-to-3 above.

## A momentary waypoint gap evicted a good entry

Since [#69](https://github.com/CybotTM/wow-quickroute/pull/69) resolves the waypoint on every read, a frame in which the client cannot say where a quest points produced a nil destination. That read as a *changed* destination, missed the cache, recomputed with no waypoint, came back incomplete and deleted the entry — an icon on screen that does nothing until `PENDING_GRACE` hides it. A nil now means "unknown", not "changed".

**What this stops detecting:** a quest that genuinely loses its waypoint for good keeps its cached teleport until `CACHE_TTL` expires it, the player moves out of tolerance, or the graph changes. That is what happened before #69, bounded at 30 seconds.

## The harness could not have caught either

The `CooldownTracker` stand-in in `test_questbutton_async.lua` answered with `ready` but no `remaining`, and the readiness check counts anything within a global cooldown of usable as ready. So `ready = false` still read as ready, every flip of `state.cooldownReady` in that file was invisible to the check, and no guard there could have depended on one. Fixed in the same commit — it is what makes the new guards mean anything.

## Tests

Both watched to fail with their fix reverted: the batch guard reports 5 client reads instead of 3 for the two quests queued after the event, and the waypoint guard finds the cache entry gone and the button's action cleared.

Suite 16,096 → 16,103, 0 failures; luacheck 0 warnings across 122 files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NfwrfURm6pysDqWAKHW9tB)_
